### PR TITLE
chore: fix TS type errors in eslint config

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -14,9 +14,7 @@ export default tseslint.config(
 				projectService: {
 					allowDefaultProject: [
 						'eslint.config.js',
-						'eslint.config.mts',
-						'manifest.json',
-						'declarations.d.ts'
+						'manifest.json'
 					]
 				},
 				// @ts-expect-error -- Node 20.11+ feature, might not be in types yet

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
 		"strictNullChecks": true,
 		"strictBindCallApply": true,
 		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
 		"useUnknownInCatchVariables": true,
 		"lib": [
 			"DOM",
@@ -26,6 +27,8 @@
 		]
 	},
 	"include": [
-		"src/**/*.ts"
+		"src/**/*.ts",
+		"declarations.d.ts",
+		"eslint.config.mts"
 	]
 }


### PR DESCRIPTION
Include eslint.config.mts in tsconfig.json to resolve missing type declaration errors in VS Code. Remove the file from allowDefaultProject to prevent ESLint service conflicts.