### PR TITLE
refactor: move Gardener state file to plugin data folder

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ export default class VaultIntelligencePlugin extends Plugin implements IVaultInt
 		// 4. Initialize Gardener Infrastructure (Stage 2)
 		this.metadataManager = new MetadataManager(this.app);
 		this.ontologyService = new OntologyService(this.app, this.settings);
-		this.gardenerStateService = new GardenerStateService(this.app);
+		this.gardenerStateService = new GardenerStateService(this.app, this);
 		this.gardenerService = new GardenerService(this.app, this.geminiService, this.ontologyService, this.settings, this.gardenerStateService);
 		await this.ontologyService.initialize();
 		await this.gardenerStateService.loadState();

--- a/src/services/GardenerStateService.ts
+++ b/src/services/GardenerStateService.ts
@@ -1,4 +1,4 @@
-import { App, TFile } from "obsidian";
+import { App, Plugin, TFile } from "obsidian";
 import { logger } from "../utils/logger";
 
 export interface FileState {
@@ -14,15 +14,18 @@ export interface GardenerState {
 
 /**
  * Service to manage the persistent state of Gardener analysis.
- * Stores data in 'data/gardener-state.json' within the vault.
+ * Stores data in the plugin's data folder within the vault.
  */
 export class GardenerStateService {
     private app: App;
-    private statePath = "data/gardener-state.json";
+    private plugin: Plugin;
+    private statePath: string;
     private state: GardenerState = { files: {} };
 
-    constructor(app: App) {
+    constructor(app: App, plugin: Plugin) {
         this.app = app;
+        this.plugin = plugin;
+        this.statePath = `${this.plugin.manifest.dir}/data/gardener-state.json`;
     }
 
     /**


### PR DESCRIPTION
## Description
Relocates the  state file from the vault's  folder to the plugin's dedicated data folder. This ensures consistency with other state files like .

## Changes
- Updated  constructor to accept the  instance for context.
- Changed state path calculation to use .
- Updated  to pass the plugin instance during service initialization.
- Updated documentation comments for storage location.

## Verification
- `npm run lint` passed.
- `npm run build` passed.