### PR TITLE
feat: show list of context documents in research assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### User features
 
+- **Context Transparency**: The Research Assistant now displays a collapsible list of all "Context Documents" used to generate the answer (Resolves #59).
+- **Interactive References**: Context documents in the chat reference list are clickable (to open the note) and draggable (to insert a link into other notes).
+
 ### Developer features
 
 ## [2.2.0] - 2026-01-22

--- a/src/services/ContextAssembler.ts
+++ b/src/services/ContextAssembler.ts
@@ -13,7 +13,7 @@ export class ContextAssembler {
     /**
      * Dynamically assembles context from search results based on the provided token budget.
      */
-    public async assemble(results: VaultSearchResult[], query: string, budgetChars: number): Promise<string> {
+    public async assemble(results: VaultSearchResult[], query: string, budgetChars: number): Promise<{ context: string; usedFiles: string[] }> {
         // Define "Starvation Protection" limit
         // No single document should take up more than 25% of the budget if there are other results.
         const singleDocSoftLimit = Math.floor(budgetChars * SEARCH_CONSTANTS.SINGLE_DOC_SOFT_LIMIT_RATIO);
@@ -87,6 +87,6 @@ export class ContextAssembler {
             }
         }
 
-        return constructedContext;
+        return { context: constructedContext, usedFiles: Array.from(new Set(results.slice(0, includedCount).map(r => r.path))) };
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -548,3 +548,61 @@ a.similar-notes-link[data-score-ten="10"]:visited {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+/* Context Files List in Chat */
+.context-details {
+    margin-top: 8px;
+    font-size: 0.9em;
+    color: var(--text-muted);
+}
+
+.context-details summary {
+    cursor: pointer;
+    user-select: none;
+    padding: 4px 0;
+}
+
+.context-details summary:hover {
+    color: var(--text-normal);
+}
+
+.context-file-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-left: 12px;
+    margin-top: 4px;
+    border-left: 2px solid var(--background-modifier-border);
+}
+
+.context-file-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 4px;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+}
+
+.context-file-item:hover {
+    background-color: var(--background-modifier-hover);
+    color: var(--text-normal);
+}
+
+.context-file-icon {
+    display: flex;
+    align-items: center;
+    color: var(--text-muted);
+}
+
+.context-file-icon svg {
+    width: 14px;
+    height: 14px;
+}
+
+.context-file-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}


### PR DESCRIPTION
This PR implements feature #59: Show list of context documents in research assistant.

### Changes
- **Core Logic**: Updated  and  to track and return the list of files used in the context.
- **UI**: Added a collapsible 'Used context documents' section in .
- **Interactivity**: Clicking a document opens it in Obsidian; dragging it inserts an internal link .
- **Styles**: Added CSS for context document items and icons.

Closes #59