### PR TITLE
ci: split lint and build jobs and enforce zero warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,20 @@ permissions:
   contents: read
 
 jobs:
+    lint:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v6
+            - name: Use Node.js 22.x
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24.x
+                  cache: "npm"
+            - run: npm ci
+            - name: Run Lint
+              run: npm run lint -- --max-warnings 0
+
     build:
         runs-on: ubuntu-latest
 
@@ -21,6 +35,6 @@ jobs:
                   node-version: 24.x
                   cache: "npm"
             - run: npm ci
-            - run: npm run build --if-present
-            - run: npm run lint
+            - name: Run Build
+              run: npm run build --if-present
 


### PR DESCRIPTION
This PR splits the CI workflow into two separate jobs for better visibility in the GitHub UI and enforces a zero-warning policy for linting.