### PR TITLE
389 mcp server linux mcp server connection failed typeerror crspawn is not a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ New features are added in the "[Unreleased]" section.
 
 ### Developer features
 
+-   **Fixed upstream changes**: Fixed a know interoperability issue when Obsidian's bundler (esbuild) encounters `@modelcontextprotocol/sdk`.
 -   **Gardener Budgeting Hardening**: Implemented a 20% safety margin (`CONTEXT_SAFETY_MARGIN`) and adopted a more conservative token estimation ratio (3.0 chars/token) for Gardener payloads to prevent API truncation or failures.
 -   **Realistic Overhead Estimation**: Improved base prompt overhead calculation for Gardener to account for system instructions and complex JSON schemas.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ New features are added in the "[Unreleased]" section.
 
 ### Developer features
 
--   **Fixed upstream changes**: Fixed a know interoperability issue when Obsidian's bundler (esbuild) encounters `@modelcontextprotocol/sdk`.
--   **Gardener Budgeting Hardening**: Implemented a 20% safety margin (`CONTEXT_SAFETY_MARGIN`) and adopted a more conservative token estimation ratio (3.0 chars/token) for Gardener payloads to prevent API truncation or failures.
+-   **Fixed upstream changes**: Fixed a know interoperability issue when Obsidian's bundler (esbuild) encounters `@modelcontextprotocol/sdk`. See Issue [389](https://github.com/cybaea/obsidian-vault-intelligence/issues/389).
+-   **Gardener Budgeting Hardening**: Implemented a 20% safety margin (`CONTEXT_SAFETY_MARGIN`) and adopted a more conservative token estimation ratio (3.0 chars/token) for Gardener payloads to prevent API truncation or failures. See Issue [388](https://github.com/cybaea/obsidian-vault-intelligence/pull/388) and [387](https://github.com/cybaea/obsidian-vault-intelligence/issues/387).
 -   **Realistic Overhead Estimation**: Improved base prompt overhead calculation for Gardener to account for system instructions and complex JSON schemas.
 
 ## [9.2.4] - 2026-04-10

--- a/src/services/mcp/StdioTransportStrategy.ts
+++ b/src/services/mcp/StdioTransportStrategy.ts
@@ -19,7 +19,10 @@ interface ChildProcessMinimal {
 }
 
 interface ChildProcessModule {
-    spawn: (command: string, args: string[], options?: unknown) => ChildProcessMinimal;
+    default?: {
+        spawn?: (command: string, args: string[], options?: unknown) => ChildProcessMinimal;
+    };
+    spawn?: (command: string, args: string[], options?: unknown) => ChildProcessMinimal;
 }
 
 // Native implementation to bypass esbuild/CJS/ESM corruption of cross-spawn
@@ -61,34 +64,51 @@ class NativeStdioTransport implements Transport {
     }
 
     async start(): Promise<void> {
+        if (!Platform.isDesktopApp) {
+            throw new Error("child_process unavailable on mobile");
+        }
         // eslint-disable-next-line import/no-nodejs-modules -- Desktop-only child_process operations
-        const cpModule = await import("child_process") as unknown as ChildProcessModule;
+        let cpModule: unknown;
+        try {
+            cpModule = await import("child_process");
+        } catch (e) {
+            throw new Error(`Failed to load child_process: ${e instanceof Error ? e.message : "Unknown error"}`);
+        }
+        
+        // Handle bundler environments where module might be under .default or directly
+        const moduleObj = (cpModule as ChildProcessModule) || {};
+        const spawnFn = moduleObj.spawn || moduleObj.default?.spawn || (cpModule as unknown as { default: { spawn?: unknown } }).default?.spawn;
+        
+        if (typeof spawnFn !== "function") {
+            throw new Error("child_process.spawn is not a function (bundler environment issue)");
+        }
         return new Promise<void>((resolve, reject) => {
             try {
-                this.childProcess = cpModule.spawn(this.command, this.args, {
-                        env: this.env,
-                        stdio: ["pipe", "pipe", "pipe"],
-                        windowsHide: true
-                    });
+                const child = spawnFn(this.command, this.args, {
+                    env: this.env,
+                    stdio: ["pipe", "pipe", "pipe"],
+                    windowsHide: true
+                });
+                this.childProcess = child;
 
-                    let resolved = false;
+                let resolved = false;
 
-                    this.childProcess.on("error", (error: unknown) => {
-                        const err = error instanceof Error ? error : new Error(String(error));
-                        if (!resolved) {
-                            reject(err);
-                        } else if (this.onerror) {
-                            this.onerror(err);
-                        }
-                    });
-
-                    if (this.childProcess.pid) {
-                        resolved = true;
-                        resolve();
+                child.on("error", (error: unknown) => {
+                    const err = error instanceof Error ? error : new Error(String(error));
+                    if (!resolved) {
+                        reject(err);
+                    } else if (this.onerror) {
+                        this.onerror(err);
                     }
+                });
 
-                    this.childProcess.stdout.setEncoding('utf-8');
-                    this.childProcess.stdout.on("data", (chunk: string) => {
+                if (child.pid) {
+                    resolved = true;
+                    resolve();
+                }
+
+                child.stdout.setEncoding('utf-8');
+                child.stdout.on("data", (chunk: string) => {
                         this.buffer += chunk;
                         let newlineIndex;
                         while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
@@ -106,29 +126,29 @@ class NativeStdioTransport implements Transport {
                         }
                     });
 
-                    this.childProcess.stderr.setEncoding('utf-8');
-                    this.childProcess.stderr.on("data", (chunk: string) => {
-                        const str = chunk.trim();
-                        if (str) {
-                            const lower = str.toLowerCase();
-                            if (lower.includes('error') || lower.includes('critical') || lower.includes('traceback') || lower.includes('exception')) {
-                                logger.error(`[MCP ${this.serverName} STDERR] ${str}`);
-                            } else if (lower.includes('warn')) {
-                                logger.warn(`[MCP ${this.serverName} STDERR] ${str}`);
-                            } else if (lower.includes('debug') || lower.includes('trace')) {
-                                logger.debug(`[MCP ${this.serverName} STDERR] ${str}`);
-                            } else {
-                                logger.info(`[MCP ${this.serverName} STDERR] ${str}`);
-                            }
+                child.stderr.setEncoding('utf-8');
+                child.stderr.on("data", (chunk: string) => {
+                    const str = chunk.trim();
+                    if (str) {
+                        const lower = str.toLowerCase();
+                        if (lower.includes('error') || lower.includes('critical') || lower.includes('traceback') || lower.includes('exception')) {
+                            logger.error(`[MCP ${this.serverName} STDERR] ${str}`);
+                        } else if (lower.includes('warn')) {
+                            logger.warn(`[MCP ${this.serverName} STDERR] ${str}`);
+                        } else if (lower.includes('debug') || lower.includes('trace')) {
+                            logger.debug(`[MCP ${this.serverName} STDERR] ${str}`);
+                        } else {
+                            logger.info(`[MCP ${this.serverName} STDERR] ${str}`);
                         }
-                    });
-
-                this.childProcess.on("close", () => {
-                    if (this.onclose) this.onclose();
+                    }
                 });
-            } catch (e) {
-                reject(e instanceof Error ? e : new Error(String(e)));
-            }
+
+            child.on("close", () => {
+                if (this.onclose) this.onclose();
+            });
+        } catch (e) {
+            reject(e instanceof Error ? e : new Error(String(e)));
+        }
         });
     }
 }
@@ -216,18 +236,32 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
             if (pid) {
                 try {
                     // eslint-disable-next-line import/no-nodejs-modules -- Desktop-only child_process operations
-                    const cpModule = await import("child_process") as unknown as ChildProcessModule;
+                    let cpModule: unknown;
+                    try {
+                        cpModule = await import("child_process");
+                    } catch (e) {
+                        logger.warn(`Failed to load child_process for process cleanup: ${e instanceof Error ? e.message : "Unknown error"}`);
+                        return;
+                    }
+                    
+                    const moduleObj = (cpModule as ChildProcessModule) || {};
+                    const spawnFn = moduleObj.spawn || moduleObj.default?.spawn || (cpModule as unknown as { default: { spawn?: unknown } }).default?.spawn;
+                    
+                    if (typeof spawnFn !== "function") {
+                        logger.warn("child_process.spawn not available for process cleanup (bundler environment issue)");
+                        return;
+                    }
                     
                     const processLib = process as unknown as { kill: (pid: number) => void; platform: string; };
                     
                     if (processLib.platform === "win32") {
-                        const killer = cpModule.spawn("taskkill", ["/pid", String(pid), "/t", "/f"] as string[]);
+                        const killer = spawnFn("taskkill", ["/pid", String(pid), "/t", "/f"] as string[]);
                         killer.on('error', (error: unknown) => {
                             const err = error instanceof Error ? error : new Error(String(error));
                             logger.warn(`taskkill failed for MCP server ${pid}:`, err);
                         });
                     } else {
-                        const killer = cpModule.spawn("pkill", ["-P", String(pid)] as string[]);
+                        const killer = spawnFn("pkill", ["-P", String(pid)] as string[]);
                         killer.on('error', () => {
                             try { processLib.kill(pid); } catch { /* ignore */ }
                         });

--- a/src/services/mcp/StdioTransportStrategy.ts
+++ b/src/services/mcp/StdioTransportStrategy.ts
@@ -9,8 +9,6 @@ import { logger } from "../../utils/logger";
 import { IMcpTransportStrategy, McpConnectionResult, SecretResolver } from "./IMcpTransportStrategy";
 import { resolveMcpSecrets } from "./utils";
 
-declare const require: (id: string) => unknown;
-
 interface ChildProcessMinimal {
     kill: () => void;
     on: (event: string, listener: (...args: unknown[]) => void) => void;
@@ -61,7 +59,6 @@ class NativeStdioTransport implements Transport {
     async start(): Promise<void> {
         return new Promise((resolve, reject) => {
             try {
-                // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules -- required for desktop only process spawn
                 const cp = require("child_process") as { spawn: (command: string, args: string[], options: unknown) => ChildProcessMinimal };
 
                 this.childProcess = cp.spawn(this.command, this.args, {
@@ -214,7 +211,6 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
 
             if (pid) {
                 try {
-                    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules -- required for desktop only process termination
                     const cp = require('child_process') as { spawn: (command: string, args: string[]) => ChildProcessMinimal };
                     
                     const processLib = process as unknown as { kill: (pid: number) => void; platform: string; };

--- a/src/services/mcp/StdioTransportStrategy.ts
+++ b/src/services/mcp/StdioTransportStrategy.ts
@@ -58,7 +58,7 @@ class NativeStdioTransport implements Transport {
 
     async start(): Promise<void> {
         // eslint-disable-next-line import/no-nodejs-modules, @typescript-eslint/no-require-imports -- Desktop-only child_process operations
-        const cp = require("child_process") as { spawn: (command: string, args: string[], options: unknown) => ChildProcessMinimal };
+        const cp = await import("child_process") as unknown as { spawn: (command: string, args: string[], options: unknown) => ChildProcessMinimal };
         return new Promise<void>((resolve, reject) => {
             try {
                 this.childProcess = cp.spawn(this.command, this.args, {
@@ -212,7 +212,7 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
             if (pid) {
                 try {
                     // eslint-disable-next-line import/no-nodejs-modules, @typescript-eslint/no-require-imports -- Desktop-only child_process operations
-                    const cp = require('child_process') as { spawn: (command: string, args: string[]) => ChildProcessMinimal };
+                    const cp = await import("child_process") as unknown as { spawn: (command: string, args: string[]) => ChildProcessMinimal };
                     
                     const processLib = process as unknown as { kill: (pid: number) => void; platform: string; };
                     

--- a/src/services/mcp/StdioTransportStrategy.ts
+++ b/src/services/mcp/StdioTransportStrategy.ts
@@ -67,17 +67,17 @@ class NativeStdioTransport implements Transport {
         if (!Platform.isDesktopApp) {
             throw new Error("child_process unavailable on mobile");
         }
-        // eslint-disable-next-line import/no-nodejs-modules -- Desktop-only child_process operations
         let cpModule: unknown;
         try {
+            // eslint-disable-next-line import/no-nodejs-modules -- Desktop-only child_process operations
             cpModule = await import("child_process");
         } catch (e) {
             throw new Error(`Failed to load child_process: ${e instanceof Error ? e.message : "Unknown error"}`);
         }
         
         // Handle bundler environments where module might be under .default or directly
-        const moduleObj = (cpModule as ChildProcessModule) || {};
-        const spawnFn = moduleObj.spawn || moduleObj.default?.spawn || (cpModule as unknown as { default: { spawn?: unknown } }).default?.spawn;
+        const moduleObj = cpModule as ChildProcessModule;
+        const spawnFn = moduleObj.spawn || moduleObj.default?.spawn;
         
         if (typeof spawnFn !== "function") {
             throw new Error("child_process.spawn is not a function (bundler environment issue)");
@@ -235,24 +235,24 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
 
             if (pid) {
                 try {
-                    // eslint-disable-next-line import/no-nodejs-modules -- Desktop-only child_process operations
                     let cpModule: unknown;
                     try {
+                        // eslint-disable-next-line import/no-nodejs-modules -- Desktop-only child_process operations
                         cpModule = await import("child_process");
                     } catch (e) {
                         logger.warn(`Failed to load child_process for process cleanup: ${e instanceof Error ? e.message : "Unknown error"}`);
                         return;
                     }
                     
-                    const moduleObj = (cpModule as ChildProcessModule) || {};
-                    const spawnFn = moduleObj.spawn || moduleObj.default?.spawn || (cpModule as unknown as { default: { spawn?: unknown } }).default?.spawn;
+                    const moduleObj = cpModule as ChildProcessModule;
+                    const spawnFn = moduleObj.spawn || moduleObj.default?.spawn;
                     
                     if (typeof spawnFn !== "function") {
                         logger.warn("child_process.spawn not available for process cleanup (bundler environment issue)");
                         return;
                     }
                     
-                    const processLib = process as unknown as { kill: (pid: number) => void; platform: string; };
+                    const processLib = process as { kill: (pid: number) => void; platform: string };
                     
                     if (processLib.platform === "win32") {
                         const killer = spawnFn("taskkill", ["/pid", String(pid), "/t", "/f"] as string[]);

--- a/src/services/mcp/StdioTransportStrategy.ts
+++ b/src/services/mcp/StdioTransportStrategy.ts
@@ -63,14 +63,18 @@ class NativeStdioTransport implements Transport {
         
         return new Promise<void>((resolve, reject) => {
             try {
-                // Bypass esbuild static analysis completely using dynamic require
-                // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Required to bypass esbuild static analysis
-                const cpModule = (typeof window !== 'undefined' && 'require' in window) 
-                    ? (window as unknown as { require: (m: string) => unknown }).require("child_process")
-                    // eslint-disable-next-line @typescript-eslint/no-implied-eval -- safe eval for require
-                    : new Function('return require("child_process")')();
+                // Dynamically pull native require to completely bypass esbuild bundling 
+                // while remaining strictly typed to satisfy ESLint
+                const req = (typeof window !== "undefined" && "require" in window)
+                    ? (window as unknown as { require: (id: string) => unknown }).require
+                    : (globalThis as unknown as { require?: (id: string) => unknown }).require;
 
-                const spawnFn = (cpModule as { spawn: (command: string, args: string[], options: unknown) => ChildProcessMinimal }).spawn;
+                if (typeof req !== "function") {
+                    throw new Error("Native require is not available in this environment");
+                }
+
+                const cpModule = req("child_process") as { spawn?: (command: string, args: string[], options?: unknown) => ChildProcessMinimal };
+                const spawnFn = cpModule.spawn;
 
                 if (typeof spawnFn !== "function") {
                     throw new Error("child_process.spawn is not a function (bundler environment issue)");
@@ -135,12 +139,12 @@ class NativeStdioTransport implements Transport {
                     }
                 });
 
-            child.on("close", () => {
-                if (this.onclose) this.onclose();
-            });
-        } catch (e) {
-            reject(e instanceof Error ? e : new Error(String(e)));
-        }
+                child.on("close", () => {
+                    if (this.onclose) this.onclose();
+                });
+            } catch (e) {
+                reject(e instanceof Error ? e : new Error(String(e)));
+            }
         });
     }
 }
@@ -227,14 +231,16 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
 
             if (pid) {
                 try {
-                    // Bypass esbuild static analysis completely using dynamic require
-                    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Required to bypass esbuild static analysis
-                    const cpModule = (typeof window !== 'undefined' && 'require' in window) 
-                        ? (window as unknown as { require: (m: string) => unknown }).require("child_process")
-                        // eslint-disable-next-line @typescript-eslint/no-implied-eval -- safe eval for require
-                        : new Function('return require("child_process")')();
+                    const req = (typeof window !== "undefined" && "require" in window)
+                        ? (window as unknown as { require: (id: string) => unknown }).require
+                        : (globalThis as unknown as { require?: (id: string) => unknown }).require;
 
-                    const spawnFn = (cpModule as { spawn: (command: string, args: string[]) => ChildProcessMinimal }).spawn;
+                    if (typeof req !== "function") {
+                        logger.warn("Native require is not available for process cleanup");
+                        return;
+                    }
+                    const cpModule = req("child_process") as { spawn?: (command: string, args: string[], options?: unknown) => ChildProcessMinimal };
+                    const spawnFn = cpModule.spawn;
 
                     if (typeof spawnFn !== "function") {
                         logger.warn("child_process.spawn not available for process cleanup (bundler environment issue)");

--- a/src/services/mcp/StdioTransportStrategy.ts
+++ b/src/services/mcp/StdioTransportStrategy.ts
@@ -18,6 +18,10 @@ interface ChildProcessMinimal {
     stdout: { on: (event: string, listener: (data: string) => void) => void; setEncoding: (enc: string) => void };
 }
 
+interface ChildProcessModule {
+    spawn: (command: string, args: string[], options?: unknown) => ChildProcessMinimal;
+}
+
 // Native implementation to bypass esbuild/CJS/ESM corruption of cross-spawn
 // See also: https://github.com/cybaea/obsidian-vault-intelligence/issues/389
 class NativeStdioTransport implements Transport {
@@ -58,10 +62,10 @@ class NativeStdioTransport implements Transport {
 
     async start(): Promise<void> {
         // eslint-disable-next-line import/no-nodejs-modules -- Desktop-only child_process operations
-        const { spawn } = await import("child_process");
+        const cpModule = await import("child_process") as unknown as ChildProcessModule;
         return new Promise<void>((resolve, reject) => {
             try {
-                this.childProcess = spawn(this.command, this.args, {
+                this.childProcess = cpModule.spawn(this.command, this.args, {
                         env: this.env,
                         stdio: ["pipe", "pipe", "pipe"],
                         windowsHide: true
@@ -212,18 +216,18 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
             if (pid) {
                 try {
                     // eslint-disable-next-line import/no-nodejs-modules -- Desktop-only child_process operations
-                    const { spawn } = await import("child_process");
+                    const cpModule = await import("child_process") as unknown as ChildProcessModule;
                     
                     const processLib = process as unknown as { kill: (pid: number) => void; platform: string; };
                     
                     if (processLib.platform === "win32") {
-                        const killer = spawn("taskkill", ["/pid", String(pid), "/t", "/f"]);
+                        const killer = cpModule.spawn("taskkill", ["/pid", String(pid), "/t", "/f"] as string[]);
                         killer.on('error', (error: unknown) => {
                             const err = error instanceof Error ? error : new Error(String(error));
                             logger.warn(`taskkill failed for MCP server ${pid}:`, err);
                         });
                     } else {
-                        const killer = spawn("pkill", ["-P", String(pid)]);
+                        const killer = cpModule.spawn("pkill", ["-P", String(pid)] as string[]);
                         killer.on('error', () => {
                             try { processLib.kill(pid); } catch { /* ignore */ }
                         });

--- a/src/services/mcp/StdioTransportStrategy.ts
+++ b/src/services/mcp/StdioTransportStrategy.ts
@@ -18,13 +18,6 @@ interface ChildProcessMinimal {
     stdout: { on: (event: string, listener: (data: string) => void) => void; setEncoding: (enc: string) => void };
 }
 
-interface ChildProcessModule {
-    default?: {
-        spawn?: (command: string, args: string[], options?: unknown) => ChildProcessMinimal;
-    };
-    spawn?: (command: string, args: string[], options?: unknown) => ChildProcessMinimal;
-}
-
 // Native implementation to bypass esbuild/CJS/ESM corruption of cross-spawn
 // See also: https://github.com/cybaea/obsidian-vault-intelligence/issues/389
 class NativeStdioTransport implements Transport {
@@ -67,23 +60,22 @@ class NativeStdioTransport implements Transport {
         if (!Platform.isDesktopApp) {
             throw new Error("child_process unavailable on mobile");
         }
-        let cpModule: unknown;
-        try {
-            // eslint-disable-next-line import/no-nodejs-modules -- Desktop-only child_process operations
-            cpModule = await import("child_process");
-        } catch (e) {
-            throw new Error(`Failed to load child_process: ${e instanceof Error ? e.message : "Unknown error"}`);
-        }
         
-        // Handle bundler environments where module might be under .default or directly
-        const moduleObj = cpModule as ChildProcessModule;
-        const spawnFn = moduleObj.spawn || moduleObj.default?.spawn;
-        
-        if (typeof spawnFn !== "function") {
-            throw new Error("child_process.spawn is not a function (bundler environment issue)");
-        }
         return new Promise<void>((resolve, reject) => {
             try {
+                // Bypass esbuild static analysis completely using dynamic require
+                // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Required to bypass esbuild static analysis
+                const cpModule = (typeof window !== 'undefined' && 'require' in window) 
+                    ? (window as unknown as { require: (m: string) => unknown }).require("child_process")
+                    // eslint-disable-next-line @typescript-eslint/no-implied-eval -- safe eval for require
+                    : new Function('return require("child_process")')();
+
+                const spawnFn = (cpModule as { spawn: (command: string, args: string[], options: unknown) => ChildProcessMinimal }).spawn;
+
+                if (typeof spawnFn !== "function") {
+                    throw new Error("child_process.spawn is not a function (bundler environment issue)");
+                }
+
                 const child = spawnFn(this.command, this.args, {
                     env: this.env,
                     stdio: ["pipe", "pipe", "pipe"],
@@ -235,33 +227,30 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
 
             if (pid) {
                 try {
-                    let cpModule: unknown;
-                    try {
-                        // eslint-disable-next-line import/no-nodejs-modules -- Desktop-only child_process operations
-                        cpModule = await import("child_process");
-                    } catch (e) {
-                        logger.warn(`Failed to load child_process for process cleanup: ${e instanceof Error ? e.message : "Unknown error"}`);
-                        return;
-                    }
-                    
-                    const moduleObj = cpModule as ChildProcessModule;
-                    const spawnFn = moduleObj.spawn || moduleObj.default?.spawn;
-                    
+                    // Bypass esbuild static analysis completely using dynamic require
+                    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Required to bypass esbuild static analysis
+                    const cpModule = (typeof window !== 'undefined' && 'require' in window) 
+                        ? (window as unknown as { require: (m: string) => unknown }).require("child_process")
+                        // eslint-disable-next-line @typescript-eslint/no-implied-eval -- safe eval for require
+                        : new Function('return require("child_process")')();
+
+                    const spawnFn = (cpModule as { spawn: (command: string, args: string[]) => ChildProcessMinimal }).spawn;
+
                     if (typeof spawnFn !== "function") {
                         logger.warn("child_process.spawn not available for process cleanup (bundler environment issue)");
                         return;
                     }
                     
-                    const processLib = process as { kill: (pid: number) => void; platform: string };
+                    const processLib = process as unknown as { kill: (pid: number) => void; platform: string; };
                     
-                    if (processLib.platform === "win32") {
-                        const killer = spawnFn("taskkill", ["/pid", String(pid), "/t", "/f"] as string[]);
+                    if (processLib.platform === 'win32') {
+                        const killer = spawnFn('taskkill', ['/pid', String(pid), '/t', '/f']);
                         killer.on('error', (error: unknown) => {
                             const err = error instanceof Error ? error : new Error(String(error));
                             logger.warn(`taskkill failed for MCP server ${pid}:`, err);
                         });
                     } else {
-                        const killer = spawnFn("pkill", ["-P", String(pid)] as string[]);
+                        const killer = spawnFn('pkill', ['-P', String(pid)]);
                         killer.on('error', () => {
                             try { processLib.kill(pid); } catch { /* ignore */ }
                         });

--- a/src/services/mcp/StdioTransportStrategy.ts
+++ b/src/services/mcp/StdioTransportStrategy.ts
@@ -1,4 +1,4 @@
-/* global process, require -- Native Node.js globals available on desktop */
+/* global process -- Native Node.js global available on desktop */
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
@@ -57,11 +57,11 @@ class NativeStdioTransport implements Transport {
     }
 
     async start(): Promise<void> {
-        // eslint-disable-next-line import/no-nodejs-modules, @typescript-eslint/no-require-imports -- Desktop-only child_process operations
-        const cp = await import("child_process") as unknown as { spawn: (command: string, args: string[], options: unknown) => ChildProcessMinimal };
+        // eslint-disable-next-line import/no-nodejs-modules -- Desktop-only child_process operations
+        const { spawn } = await import("child_process");
         return new Promise<void>((resolve, reject) => {
             try {
-                this.childProcess = cp.spawn(this.command, this.args, {
+                this.childProcess = spawn(this.command, this.args, {
                         env: this.env,
                         stdio: ["pipe", "pipe", "pipe"],
                         windowsHide: true
@@ -211,19 +211,19 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
 
             if (pid) {
                 try {
-                    // eslint-disable-next-line import/no-nodejs-modules, @typescript-eslint/no-require-imports -- Desktop-only child_process operations
-                    const cp = await import("child_process") as unknown as { spawn: (command: string, args: string[]) => ChildProcessMinimal };
+                    // eslint-disable-next-line import/no-nodejs-modules -- Desktop-only child_process operations
+                    const { spawn } = await import("child_process");
                     
                     const processLib = process as unknown as { kill: (pid: number) => void; platform: string; };
                     
-                    if (processLib.platform === 'win32') {
-                        const killer = cp.spawn('taskkill', ['/pid', String(pid), '/t', '/f']);
+                    if (processLib.platform === "win32") {
+                        const killer = spawn("taskkill", ["/pid", String(pid), "/t", "/f"]);
                         killer.on('error', (error: unknown) => {
                             const err = error instanceof Error ? error : new Error(String(error));
                             logger.warn(`taskkill failed for MCP server ${pid}:`, err);
                         });
                     } else {
-                        const killer = cp.spawn('pkill', ['-P', String(pid)]);
+                        const killer = spawn("pkill", ["-P", String(pid)]);
                         killer.on('error', () => {
                             try { processLib.kill(pid); } catch { /* ignore */ }
                         });

--- a/src/services/mcp/StdioTransportStrategy.ts
+++ b/src/services/mcp/StdioTransportStrategy.ts
@@ -1,4 +1,4 @@
-/* global process -- Native Node.js global available on desktop */
+/* global process, require -- Native Node.js globals available on desktop */
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
@@ -8,6 +8,8 @@ import { MCPServerConfig } from "../../settings/types";
 import { logger } from "../../utils/logger";
 import { IMcpTransportStrategy, McpConnectionResult, SecretResolver } from "./IMcpTransportStrategy";
 import { resolveMcpSecrets } from "./utils";
+
+declare const require: (id: string) => unknown;
 
 interface ChildProcessMinimal {
     kill: () => void;
@@ -58,76 +60,74 @@ class NativeStdioTransport implements Transport {
 
     async start(): Promise<void> {
         return new Promise((resolve, reject) => {
-            // eslint-disable-next-line import/no-nodejs-modules -- required for desktop only process spawn
-            import("child_process").then((cp) => {
-                try {
-                    this.childProcess = cp.spawn(this.command, this.args, {
-                        env: this.env,
-                        stdio: ["pipe", "pipe", "pipe"],
-                        windowsHide: true
-                    }) as unknown as ChildProcessMinimal;
+            try {
+                // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules -- required for desktop only process spawn
+                const cp = require("child_process") as { spawn: (command: string, args: string[], options: unknown) => ChildProcessMinimal };
 
-                    let resolved = false;
+                this.childProcess = cp.spawn(this.command, this.args, {
+                    env: this.env,
+                    stdio: ["pipe", "pipe", "pipe"],
+                    windowsHide: true
+                });
 
-                    this.childProcess.on("error", (error: unknown) => {
-                        const err = error instanceof Error ? error : new Error(String(error));
-                        if (!resolved) {
-                            reject(err);
-                        } else if (this.onerror) {
-                            this.onerror(err);
-                        }
-                    });
+                let resolved = false;
 
-                    if (this.childProcess.pid) {
-                        resolved = true;
-                        resolve();
+                this.childProcess.on("error", (error: unknown) => {
+                    const err = error instanceof Error ? error : new Error(String(error));
+                    if (!resolved) {
+                        reject(err);
+                    } else if (this.onerror) {
+                        this.onerror(err);
                     }
+                });
 
-                    this.childProcess.stdout.setEncoding('utf-8');
-                    this.childProcess.stdout.on("data", (chunk: string) => {
-                        this.buffer += chunk;
-                        let newlineIndex;
-                        while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
-                            const line = this.buffer.slice(0, newlineIndex);
-                            this.buffer = this.buffer.slice(newlineIndex + 1);
-                            const trimmed = line.trim();
-                            if (trimmed) {
-                                try {
-                                    const message = JSON.parse(trimmed) as JSONRPCMessage;
-                                    if (this.onmessage) this.onmessage(message);
-                                } catch {
-                                    if (this.onerror) this.onerror(new Error("Failed to parse MCP message: " + trimmed));
-                                }
-                            }
-                        }
-                    });
-
-                    this.childProcess.stderr.setEncoding('utf-8');
-                    this.childProcess.stderr.on("data", (chunk: string) => {
-                        const str = chunk.trim();
-                        if (str) {
-                            const lower = str.toLowerCase();
-                            if (lower.includes('error') || lower.includes('critical') || lower.includes('traceback') || lower.includes('exception')) {
-                                logger.error(`[MCP ${this.serverName} STDERR] ${str}`);
-                            } else if (lower.includes('warn')) {
-                                logger.warn(`[MCP ${this.serverName} STDERR] ${str}`);
-                            } else if (lower.includes('debug') || lower.includes('trace')) {
-                                logger.debug(`[MCP ${this.serverName} STDERR] ${str}`);
-                            } else {
-                                logger.info(`[MCP ${this.serverName} STDERR] ${str}`);
-                            }
-                        }
-                    });
-
-                    this.childProcess.on("close", () => {
-                        if (this.onclose) this.onclose();
-                    });
-                } catch (e) {
-                    reject(e instanceof Error ? e : new Error(String(e)));
+                if (this.childProcess.pid) {
+                    resolved = true;
+                    resolve();
                 }
-            }).catch((err: unknown) => {
-                reject(err instanceof Error ? err : new Error(String(err)));
-            });
+
+                this.childProcess.stdout.setEncoding('utf-8');
+                this.childProcess.stdout.on("data", (chunk: string) => {
+                    this.buffer += chunk;
+                    let newlineIndex;
+                    while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
+                        const line = this.buffer.slice(0, newlineIndex);
+                        this.buffer = this.buffer.slice(newlineIndex + 1);
+                        const trimmed = line.trim();
+                        if (trimmed) {
+                            try {
+                                const message = JSON.parse(trimmed) as JSONRPCMessage;
+                                if (this.onmessage) this.onmessage(message);
+                            } catch {
+                                if (this.onerror) this.onerror(new Error("Failed to parse MCP message: " + trimmed));
+                            }
+                        }
+                    }
+                });
+
+                this.childProcess.stderr.setEncoding('utf-8');
+                this.childProcess.stderr.on("data", (chunk: string) => {
+                    const str = chunk.trim();
+                    if (str) {
+                        const lower = str.toLowerCase();
+                        if (lower.includes('error') || lower.includes('critical') || lower.includes('traceback') || lower.includes('exception')) {
+                            logger.error(`[MCP ${this.serverName} STDERR] ${str}`);
+                        } else if (lower.includes('warn')) {
+                            logger.warn(`[MCP ${this.serverName} STDERR] ${str}`);
+                        } else if (lower.includes('debug') || lower.includes('trace')) {
+                            logger.debug(`[MCP ${this.serverName} STDERR] ${str}`);
+                        } else {
+                            logger.info(`[MCP ${this.serverName} STDERR] ${str}`);
+                        }
+                    }
+                });
+
+                this.childProcess.on("close", () => {
+                    if (this.onclose) this.onclose();
+                });
+            } catch (e) {
+                reject(e instanceof Error ? e : new Error(String(e)));
+            }
         });
     }
 }
@@ -214,14 +214,17 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
 
             if (pid) {
                 try {
-                    // eslint-disable-next-line import/no-nodejs-modules -- required for desktop only process termination
-                    const cp = await import('child_process');
+                    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules -- required for desktop only process termination
+                    const cp = require('child_process') as { spawn: (command: string, args: string[]) => ChildProcessMinimal };
                     
                     const processLib = process as unknown as { kill: (pid: number) => void; platform: string; };
                     
                     if (processLib.platform === 'win32') {
                         const killer = cp.spawn('taskkill', ['/pid', String(pid), '/t', '/f']);
-                        killer.on('error', (err: Error) => logger.warn(`taskkill failed for MCP server ${pid}:`, err));
+                        killer.on('error', (error: unknown) => {
+                            const err = error instanceof Error ? error : new Error(String(error));
+                            logger.warn(`taskkill failed for MCP server ${pid}:`, err);
+                        });
                     } else {
                         const killer = cp.spawn('pkill', ['-P', String(pid)]);
                         killer.on('error', () => {

--- a/src/services/mcp/StdioTransportStrategy.ts
+++ b/src/services/mcp/StdioTransportStrategy.ts
@@ -1,5 +1,7 @@
 /* global process -- Native Node.js global available on desktop */
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import { Platform } from "obsidian";
 
 import { MCPServerConfig } from "../../settings/types";
@@ -7,114 +9,126 @@ import { logger } from "../../utils/logger";
 import { IMcpTransportStrategy, McpConnectionResult, SecretResolver } from "./IMcpTransportStrategy";
 import { resolveMcpSecrets } from "./utils";
 
+interface ChildProcessMinimal {
+    kill: () => void;
+    on: (event: string, listener: (...args: unknown[]) => void) => void;
+    pid?: number;
+    stderr: { on: (event: string, listener: (data: string) => void) => void; setEncoding: (enc: string) => void };
+    stdin: { write: (data: string, cb: (err?: Error) => void) => void };
+    stdout: { on: (event: string, listener: (data: string) => void) => void; setEncoding: (enc: string) => void };
+}
+
 // Native implementation to bypass esbuild/CJS/ESM corruption of cross-spawn
 // See also: https://github.com/cybaea/obsidian-vault-intelligence/issues/389
-class NativeStdioTransport {
-    private process: any = null;
+class NativeStdioTransport implements Transport {
     private buffer: string = "";
+    private childProcess: ChildProcessMinimal | null = null;
     
     public onclose?: () => void;
     public onerror?: (error: Error) => void;
-    public onmessage?: (message: any) => void;
+    public onmessage?: (message: JSONRPCMessage) => void;
 
     constructor(private command: string, private args: string[], private env: Record<string, string>, private serverName: string) {}
 
-    async start(): Promise<void> {
-        return new Promise((resolve, reject) => {
-            try {
-                // eslint-disable-next-line @typescript-eslint/no-var-requires
-                const cp = require("child_process");
-                
-                this.process = cp.spawn(this.command, this.args, {
-                    env: this.env,
-                    stdio: ["pipe", "pipe", "pipe"],
-                    windowsHide: true
-                });
-
-                let resolved = false;
-
-                this.process.on("error", (error: Error) => {
-                    if (!resolved) {
-                        reject(error);
-                    } else if (this.onerror) {
-                        this.onerror(error);
-                    }
-                });
-
-                if (this.process.pid) {
-                    resolved = true;
-                    resolve();
-                }
-
-                this.process.stdout.setEncoding('utf-8');
-                this.process.stdout.on("data", (chunk: string) => {
-                    this.buffer += chunk;
-                    let newlineIndex;
-                    while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
-                        const line = this.buffer.slice(0, newlineIndex);
-                        this.buffer = this.buffer.slice(newlineIndex + 1);
-                        const trimmed = line.trim();
-                        if (trimmed) {
-                            try {
-                                const message = JSON.parse(trimmed);
-                                if (this.onmessage) this.onmessage(message);
-                            } catch (e) {
-                                if (this.onerror) this.onerror(new Error("Failed to parse MCP message: " + trimmed));
-                            }
-                        }
-                    }
-                });
-
-                this.process.stderr.setEncoding('utf-8');
-                this.process.stderr.on("data", (chunk: string) => {
-                    const str = chunk.trim();
-                    if (str) {
-                        const lower = str.toLowerCase();
-                        if (lower.includes('error') || lower.includes('critical') || lower.includes('traceback') || lower.includes('exception')) {
-                            logger.error(`[MCP ${this.serverName} STDERR] ${str}`);
-                        } else if (lower.includes('warn')) {
-                            logger.warn(`[MCP ${this.serverName} STDERR] ${str}`);
-                        } else if (lower.includes('debug') || lower.includes('trace')) {
-                            logger.debug(`[MCP ${this.serverName} STDERR] ${str}`);
-                        } else {
-                            logger.info(`[MCP ${this.serverName} STDERR] ${str}`);
-                        }
-                    }
-                });
-
-                this.process.on("close", () => {
-                    if (this.onclose) this.onclose();
-                });
-
-            } catch (e) {
-                reject(e);
-            }
-        });
-    }
-
     async close(): Promise<void> {
-        if (this.process) {
-            this.process.kill();
-            this.process = null;
+        if (this.childProcess) {
+            this.childProcess.kill();
+            this.childProcess = null;
         }
         if (this.onclose) this.onclose();
+        return Promise.resolve();
     }
 
-    async send(message: any): Promise<void> {
+    get pid(): number | null {
+        return this.childProcess ? (this.childProcess.pid ?? null) : null;
+    }
+
+    async send(message: JSONRPCMessage): Promise<void> {
         return new Promise((resolve, reject) => {
-            if (!this.process || !this.process.stdin) {
+            if (!this.childProcess || !this.childProcess.stdin) {
                 return reject(new Error("MCP Process not running"));
             }
             const json = JSON.stringify(message);
-            this.process.stdin.write(json + "\n", (err: Error) => {
+            this.childProcess.stdin.write(json + "\n", (err?: Error) => {
                 if (err) reject(err);
                 else resolve();
             });
         });
     }
 
-    get pid() {
-        return this.process ? this.process.pid : null;
+    async start(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            // eslint-disable-next-line import/no-nodejs-modules -- required for desktop only process spawn
+            import("child_process").then((cp) => {
+                try {
+                    this.childProcess = cp.spawn(this.command, this.args, {
+                        env: this.env,
+                        stdio: ["pipe", "pipe", "pipe"],
+                        windowsHide: true
+                    }) as unknown as ChildProcessMinimal;
+
+                    let resolved = false;
+
+                    this.childProcess.on("error", (error: unknown) => {
+                        const err = error instanceof Error ? error : new Error(String(error));
+                        if (!resolved) {
+                            reject(err);
+                        } else if (this.onerror) {
+                            this.onerror(err);
+                        }
+                    });
+
+                    if (this.childProcess.pid) {
+                        resolved = true;
+                        resolve();
+                    }
+
+                    this.childProcess.stdout.setEncoding('utf-8');
+                    this.childProcess.stdout.on("data", (chunk: string) => {
+                        this.buffer += chunk;
+                        let newlineIndex;
+                        while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
+                            const line = this.buffer.slice(0, newlineIndex);
+                            this.buffer = this.buffer.slice(newlineIndex + 1);
+                            const trimmed = line.trim();
+                            if (trimmed) {
+                                try {
+                                    const message = JSON.parse(trimmed) as JSONRPCMessage;
+                                    if (this.onmessage) this.onmessage(message);
+                                } catch {
+                                    if (this.onerror) this.onerror(new Error("Failed to parse MCP message: " + trimmed));
+                                }
+                            }
+                        }
+                    });
+
+                    this.childProcess.stderr.setEncoding('utf-8');
+                    this.childProcess.stderr.on("data", (chunk: string) => {
+                        const str = chunk.trim();
+                        if (str) {
+                            const lower = str.toLowerCase();
+                            if (lower.includes('error') || lower.includes('critical') || lower.includes('traceback') || lower.includes('exception')) {
+                                logger.error(`[MCP ${this.serverName} STDERR] ${str}`);
+                            } else if (lower.includes('warn')) {
+                                logger.warn(`[MCP ${this.serverName} STDERR] ${str}`);
+                            } else if (lower.includes('debug') || lower.includes('trace')) {
+                                logger.debug(`[MCP ${this.serverName} STDERR] ${str}`);
+                            } else {
+                                logger.info(`[MCP ${this.serverName} STDERR] ${str}`);
+                            }
+                        }
+                    });
+
+                    this.childProcess.on("close", () => {
+                        if (this.onclose) this.onclose();
+                    });
+                } catch (e) {
+                    reject(e instanceof Error ? e : new Error(String(e)));
+                }
+            }).catch((err: unknown) => {
+                reject(err instanceof Error ? err : new Error(String(err)));
+            });
+        });
     }
 }
 
@@ -184,7 +198,7 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
         });
 
         // The SDK's Client.connect accepts any standard implementation matching the Transport interface
-        await client.connect(transport as any);
+        await client.connect(transport);
 
         return { client, transport };
     }
@@ -200,8 +214,8 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
 
             if (pid) {
                 try {
-                    // eslint-disable-next-line @typescript-eslint/no-var-requires
-                    const cp = require('child_process');
+                    // eslint-disable-next-line import/no-nodejs-modules -- required for desktop only process termination
+                    const cp = await import('child_process');
                     
                     const processLib = process as unknown as { kill: (pid: number) => void; platform: string; };
                     

--- a/src/services/mcp/StdioTransportStrategy.ts
+++ b/src/services/mcp/StdioTransportStrategy.ts
@@ -7,21 +7,127 @@ import { logger } from "../../utils/logger";
 import { IMcpTransportStrategy, McpConnectionResult, SecretResolver } from "./IMcpTransportStrategy";
 import { resolveMcpSecrets } from "./utils";
 
+// Native implementation to bypass esbuild/CJS/ESM corruption of cross-spawn
+// See also: https://github.com/cybaea/obsidian-vault-intelligence/issues/389
+class NativeStdioTransport {
+    private process: any = null;
+    private buffer: string = "";
+    
+    public onclose?: () => void;
+    public onerror?: (error: Error) => void;
+    public onmessage?: (message: any) => void;
+
+    constructor(private command: string, private args: string[], private env: Record<string, string>, private serverName: string) {}
+
+    async start(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            try {
+                // eslint-disable-next-line @typescript-eslint/no-var-requires
+                const cp = require("child_process");
+                
+                this.process = cp.spawn(this.command, this.args, {
+                    env: this.env,
+                    stdio: ["pipe", "pipe", "pipe"],
+                    windowsHide: true
+                });
+
+                let resolved = false;
+
+                this.process.on("error", (error: Error) => {
+                    if (!resolved) {
+                        reject(error);
+                    } else if (this.onerror) {
+                        this.onerror(error);
+                    }
+                });
+
+                if (this.process.pid) {
+                    resolved = true;
+                    resolve();
+                }
+
+                this.process.stdout.setEncoding('utf-8');
+                this.process.stdout.on("data", (chunk: string) => {
+                    this.buffer += chunk;
+                    let newlineIndex;
+                    while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
+                        const line = this.buffer.slice(0, newlineIndex);
+                        this.buffer = this.buffer.slice(newlineIndex + 1);
+                        const trimmed = line.trim();
+                        if (trimmed) {
+                            try {
+                                const message = JSON.parse(trimmed);
+                                if (this.onmessage) this.onmessage(message);
+                            } catch (e) {
+                                if (this.onerror) this.onerror(new Error("Failed to parse MCP message: " + trimmed));
+                            }
+                        }
+                    }
+                });
+
+                this.process.stderr.setEncoding('utf-8');
+                this.process.stderr.on("data", (chunk: string) => {
+                    const str = chunk.trim();
+                    if (str) {
+                        const lower = str.toLowerCase();
+                        if (lower.includes('error') || lower.includes('critical') || lower.includes('traceback') || lower.includes('exception')) {
+                            logger.error(`[MCP ${this.serverName} STDERR] ${str}`);
+                        } else if (lower.includes('warn')) {
+                            logger.warn(`[MCP ${this.serverName} STDERR] ${str}`);
+                        } else if (lower.includes('debug') || lower.includes('trace')) {
+                            logger.debug(`[MCP ${this.serverName} STDERR] ${str}`);
+                        } else {
+                            logger.info(`[MCP ${this.serverName} STDERR] ${str}`);
+                        }
+                    }
+                });
+
+                this.process.on("close", () => {
+                    if (this.onclose) this.onclose();
+                });
+
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
+
+    async close(): Promise<void> {
+        if (this.process) {
+            this.process.kill();
+            this.process = null;
+        }
+        if (this.onclose) this.onclose();
+    }
+
+    async send(message: any): Promise<void> {
+        return new Promise((resolve, reject) => {
+            if (!this.process || !this.process.stdin) {
+                return reject(new Error("MCP Process not running"));
+            }
+            const json = JSON.stringify(message);
+            this.process.stdin.write(json + "\n", (err: Error) => {
+                if (err) reject(err);
+                else resolve();
+            });
+        });
+    }
+
+    get pid() {
+        return this.process ? this.process.pid : null;
+    }
+}
+
 export class StdioTransportStrategy implements IMcpTransportStrategy {
     public async connect(server: MCPServerConfig, resolveSecret: SecretResolver): Promise<McpConnectionResult> {
         if (!Platform.isDesktopApp) {
             throw new Error(`Skipping stdio MCP server ${server.name} on Mobile.`);
         }
 
-        const mcpSdk = await import('@modelcontextprotocol/sdk/client/stdio.js');
-        const StdioClientTransport = mcpSdk.StdioClientTransport;
-
-        // Construct minimal safe environment (Fix for Host Environment Leakage)
         const safeKeys = [
             'PATH', 'USER', 'HOME', 'USERPROFILE', 'APPDATA', 'TMPDIR', 'TEMP',
             'HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'http_proxy', 'https_proxy', 'no_proxy',
             'LANG', 'LC_ALL', 'PWD', 'LOGNAME', 'SHELL',
-            // Linux Desktop/DBus Requirements
             'DISPLAY', 'WAYLAND_DISPLAY', 'DBUS_SESSION_BUS_ADDRESS', 'XDG_RUNTIME_DIR', 'XAUTHORITY', 'XDG_SESSION_TYPE'
         ];
         const mergedEnv: Record<string, string> = {
@@ -67,31 +173,8 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
             throw new Error(`Configuration error: missing command`);
         }
 
-        const transportConfig = {
-            args: server.args || [],
-            command: server.command,
-            env: mergedEnv,
-            stderr: 'pipe' as const
-        };
-        const transport = new StdioClientTransport(transportConfig);
-
-        if (transport.stderr) {
-            transport.stderr.on('data', (chunk: { toString: () => string }) => {
-                const str = chunk.toString().trim();
-                if (str) {
-                    const lower = str.toLowerCase();
-                    if (lower.includes('error') || lower.includes('critical') || lower.includes('traceback') || lower.includes('exception')) {
-                        logger.error(`[MCP ${server.name} STDERR] ${str}`);
-                    } else if (lower.includes('warn')) {
-                        logger.warn(`[MCP ${server.name} STDERR] ${str}`);
-                    } else if (lower.includes('debug') || lower.includes('trace')) {
-                        logger.debug(`[MCP ${server.name} STDERR] ${str}`);
-                    } else {
-                        logger.info(`[MCP ${server.name} STDERR] ${str}`);
-                    }
-                }
-            });
-        }
+        // Initialize our Native wrapper rather than the bundled SDK
+        const transport = new NativeStdioTransport(server.command, server.args || [], mergedEnv, server.name);
 
         const client = new Client({
             name: "vault-intelligence",
@@ -100,7 +183,8 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
             capabilities: {}
         });
 
-        await client.connect(transport);
+        // The SDK's Client.connect accepts any standard implementation matching the Transport interface
+        await client.connect(transport as any);
 
         return { client, transport };
     }
@@ -116,8 +200,8 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
 
             if (pid) {
                 try {
-                    // eslint-disable-next-line import/no-nodejs-modules -- required for desktop only process termination
-                    const cp = await import('child_process');
+                    // eslint-disable-next-line @typescript-eslint/no-var-requires
+                    const cp = require('child_process');
                     
                     const processLib = process as unknown as { kill: (pid: number) => void; platform: string; };
                     

--- a/src/services/mcp/StdioTransportStrategy.ts
+++ b/src/services/mcp/StdioTransportStrategy.ts
@@ -57,67 +57,67 @@ class NativeStdioTransport implements Transport {
     }
 
     async start(): Promise<void> {
-        return new Promise((resolve, reject) => {
+        // eslint-disable-next-line import/no-nodejs-modules, @typescript-eslint/no-require-imports -- Desktop-only child_process operations
+        const cp = require("child_process") as { spawn: (command: string, args: string[], options: unknown) => ChildProcessMinimal };
+        return new Promise<void>((resolve, reject) => {
             try {
-                const cp = require("child_process") as { spawn: (command: string, args: string[], options: unknown) => ChildProcessMinimal };
-
                 this.childProcess = cp.spawn(this.command, this.args, {
-                    env: this.env,
-                    stdio: ["pipe", "pipe", "pipe"],
-                    windowsHide: true
-                });
+                        env: this.env,
+                        stdio: ["pipe", "pipe", "pipe"],
+                        windowsHide: true
+                    });
 
-                let resolved = false;
+                    let resolved = false;
 
-                this.childProcess.on("error", (error: unknown) => {
-                    const err = error instanceof Error ? error : new Error(String(error));
-                    if (!resolved) {
-                        reject(err);
-                    } else if (this.onerror) {
-                        this.onerror(err);
+                    this.childProcess.on("error", (error: unknown) => {
+                        const err = error instanceof Error ? error : new Error(String(error));
+                        if (!resolved) {
+                            reject(err);
+                        } else if (this.onerror) {
+                            this.onerror(err);
+                        }
+                    });
+
+                    if (this.childProcess.pid) {
+                        resolved = true;
+                        resolve();
                     }
-                });
 
-                if (this.childProcess.pid) {
-                    resolved = true;
-                    resolve();
-                }
-
-                this.childProcess.stdout.setEncoding('utf-8');
-                this.childProcess.stdout.on("data", (chunk: string) => {
-                    this.buffer += chunk;
-                    let newlineIndex;
-                    while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
-                        const line = this.buffer.slice(0, newlineIndex);
-                        this.buffer = this.buffer.slice(newlineIndex + 1);
-                        const trimmed = line.trim();
-                        if (trimmed) {
-                            try {
-                                const message = JSON.parse(trimmed) as JSONRPCMessage;
-                                if (this.onmessage) this.onmessage(message);
-                            } catch {
-                                if (this.onerror) this.onerror(new Error("Failed to parse MCP message: " + trimmed));
+                    this.childProcess.stdout.setEncoding('utf-8');
+                    this.childProcess.stdout.on("data", (chunk: string) => {
+                        this.buffer += chunk;
+                        let newlineIndex;
+                        while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
+                            const line = this.buffer.slice(0, newlineIndex);
+                            this.buffer = this.buffer.slice(newlineIndex + 1);
+                            const trimmed = line.trim();
+                            if (trimmed) {
+                                try {
+                                    const message = JSON.parse(trimmed) as JSONRPCMessage;
+                                    if (this.onmessage) this.onmessage(message);
+                                } catch {
+                                    if (this.onerror) this.onerror(new Error("Failed to parse MCP message: " + trimmed));
+                                }
                             }
                         }
-                    }
-                });
+                    });
 
-                this.childProcess.stderr.setEncoding('utf-8');
-                this.childProcess.stderr.on("data", (chunk: string) => {
-                    const str = chunk.trim();
-                    if (str) {
-                        const lower = str.toLowerCase();
-                        if (lower.includes('error') || lower.includes('critical') || lower.includes('traceback') || lower.includes('exception')) {
-                            logger.error(`[MCP ${this.serverName} STDERR] ${str}`);
-                        } else if (lower.includes('warn')) {
-                            logger.warn(`[MCP ${this.serverName} STDERR] ${str}`);
-                        } else if (lower.includes('debug') || lower.includes('trace')) {
-                            logger.debug(`[MCP ${this.serverName} STDERR] ${str}`);
-                        } else {
-                            logger.info(`[MCP ${this.serverName} STDERR] ${str}`);
+                    this.childProcess.stderr.setEncoding('utf-8');
+                    this.childProcess.stderr.on("data", (chunk: string) => {
+                        const str = chunk.trim();
+                        if (str) {
+                            const lower = str.toLowerCase();
+                            if (lower.includes('error') || lower.includes('critical') || lower.includes('traceback') || lower.includes('exception')) {
+                                logger.error(`[MCP ${this.serverName} STDERR] ${str}`);
+                            } else if (lower.includes('warn')) {
+                                logger.warn(`[MCP ${this.serverName} STDERR] ${str}`);
+                            } else if (lower.includes('debug') || lower.includes('trace')) {
+                                logger.debug(`[MCP ${this.serverName} STDERR] ${str}`);
+                            } else {
+                                logger.info(`[MCP ${this.serverName} STDERR] ${str}`);
+                            }
                         }
-                    }
-                });
+                    });
 
                 this.childProcess.on("close", () => {
                     if (this.onclose) this.onclose();
@@ -211,6 +211,7 @@ export class StdioTransportStrategy implements IMcpTransportStrategy {
 
             if (pid) {
                 try {
+                    // eslint-disable-next-line import/no-nodejs-modules, @typescript-eslint/no-require-imports -- Desktop-only child_process operations
                     const cp = require('child_process') as { spawn: (command: string, args: string[]) => ChildProcessMinimal };
                     
                     const processLib = process as unknown as { kill: (pid: number) => void; platform: string; };

--- a/tests/services/McpClientManager.test.ts
+++ b/tests/services/McpClientManager.test.ts
@@ -140,7 +140,7 @@ describe('McpClientManager', () => {
         const firstCall = mockSpawn.mock.calls[0] as unknown[];
         if (!firstCall) throw new Error("Expected call arguments");
         
-        const transportConfigEnv = (firstCall[2] as unknown as { env: Record<string, string> }).env;
+        const transportConfigEnv = (firstCall[2] as { env: Record<string, string> }).env;
         
         expect(transportConfigEnv).toBeDefined();
         if (transportConfigEnv) {

--- a/tests/services/McpClientManager.test.ts
+++ b/tests/services/McpClientManager.test.ts
@@ -39,6 +39,15 @@ Object.defineProperty(globalThis, 'crypto', {
     value: { subtle: mockCryptoSubtle },
 });
 
+// Inject global require for tests to map dynamic require("child_process") exactly as NativeStdioTransport expects
+Object.defineProperty(globalThis, 'require', {
+    value: (id: string) => {
+        if (id === 'child_process') return { spawn: mockSpawn };
+        throw new Error(`Cannot require ${id} in test environment`);
+    },
+    writable: true
+});
+
 // Mock localStorage
 const mockLocalStorageValue: Record<string, string> = {};
 const mockLocalStorage = {
@@ -140,7 +149,7 @@ describe('McpClientManager', () => {
         const firstCall = mockSpawn.mock.calls[0] as unknown[];
         if (!firstCall) throw new Error("Expected call arguments");
         
-        const transportConfigEnv = (firstCall[2] as { env: Record<string, string> }).env;
+        const transportConfigEnv = (firstCall[2] as { env?: Record<string, string> }).env;
         
         expect(transportConfigEnv).toBeDefined();
         if (transportConfigEnv) {

--- a/tests/services/McpClientManager.test.ts
+++ b/tests/services/McpClientManager.test.ts
@@ -6,12 +6,12 @@ import { VaultIntelligenceSettings, DEFAULT_SETTINGS, MCPServerConfig } from "..
 
 // Mock child_process globally so NativeStdioTransport works
 const mockSpawn = vi.fn().mockImplementation(() => ({
-    stdout: { setEncoding: vi.fn(), on: vi.fn() },
-    stderr: { setEncoding: vi.fn(), on: vi.fn() },
-    stdin: { write: vi.fn() },
-    on: vi.fn(),
     kill: vi.fn(),
-    pid: 12345
+    on: vi.fn(),
+    pid: 12345,
+    stderr: { on: vi.fn(), setEncoding: vi.fn() },
+    stdin: { write: vi.fn() },
+    stdout: { on: vi.fn(), setEncoding: vi.fn() }
 }));
 
 vi.mock('child_process', () => ({
@@ -132,10 +132,10 @@ describe('McpClientManager', () => {
         }
 
         expect(mockSpawn).toHaveBeenCalled();
-        const firstCall = mockSpawn.mock.calls[0];
+        const firstCall = mockSpawn.mock.calls[0] as unknown[];
         if (!firstCall) throw new Error("Expected call arguments");
         
-        const transportConfigEnv = firstCall[2].env;
+        const transportConfigEnv = (firstCall[2] as { env?: Record<string, string> }).env;
         
         expect(transportConfigEnv).toBeDefined();
         if (transportConfigEnv) {
@@ -152,7 +152,7 @@ describe('McpClientManager', () => {
             id: 'test-remote',
             name: 'Remote Server',
             type: 'streamable_http' as const,
-            url: '[http://example.com/mcp](http://example.com/mcp)'
+            url: 'http://example.com/mcp'
         } as MCPServerConfig;
 
         const managerWithInternal = manager as unknown as { 
@@ -177,7 +177,7 @@ describe('McpClientManager', () => {
             name: 'Malicious Local Server',
             requireExplicitConfirmation: false,
             type: 'streamable_http' as const,
-            url: '[http://169.254.169.254/latest/meta-data/](http://169.254.169.254/latest/meta-data/)'
+            url: 'http://169.254.169.254/latest/meta-data/'
         };
 
         const managerWithInternal = manager as unknown as { 
@@ -204,7 +204,7 @@ describe('McpClientManager', () => {
                 "Authorization": "vi-secret:invalid-secret"
             }),
             type: 'sse' as const,
-            url: '[https://example.com/sse](https://example.com/sse)'
+            url: 'https://example.com/sse'
         };
 
         mockLocalStorageValue[`vi-mcp-trust-${sseConfig.id}`] = '0102030405';

--- a/tests/services/McpClientManager.test.ts
+++ b/tests/services/McpClientManager.test.ts
@@ -140,7 +140,7 @@ describe('McpClientManager', () => {
         const firstCall = mockSpawn.mock.calls[0] as unknown[];
         if (!firstCall) throw new Error("Expected call arguments");
         
-        const transportConfigEnv = (firstCall[2] as { env?: Record<string, string> }).env;
+        const transportConfigEnv = (firstCall[2] as unknown as { env: Record<string, string> }).env;
         
         expect(transportConfigEnv).toBeDefined();
         if (transportConfigEnv) {

--- a/tests/services/McpClientManager.test.ts
+++ b/tests/services/McpClientManager.test.ts
@@ -10,7 +10,12 @@ const mockSpawn = vi.fn().mockImplementation(() => ({
     on: vi.fn(),
     pid: 12345,
     stderr: { on: vi.fn(), setEncoding: vi.fn() },
-    stdin: { write: vi.fn() },
+    stdin: { 
+        write: vi.fn((data: string, cb: (err?: Error) => void) => {
+            // Fail the handshake immediately to prevent the SDK's client.connect() from hanging
+            if (typeof cb === 'function') cb(new Error("Mock write error to prevent hang"));
+        })
+    },
     stdout: { on: vi.fn(), setEncoding: vi.fn() }
 }));
 
@@ -152,7 +157,7 @@ describe('McpClientManager', () => {
             id: 'test-remote',
             name: 'Remote Server',
             type: 'streamable_http' as const,
-            url: 'http://example.com/mcp'
+            url: '[http://example.com/mcp](http://example.com/mcp)'
         } as MCPServerConfig;
 
         const managerWithInternal = manager as unknown as { 
@@ -177,7 +182,7 @@ describe('McpClientManager', () => {
             name: 'Malicious Local Server',
             requireExplicitConfirmation: false,
             type: 'streamable_http' as const,
-            url: 'http://169.254.169.254/latest/meta-data/'
+            url: '[http://169.254.169.254/latest/meta-data/](http://169.254.169.254/latest/meta-data/)'
         };
 
         const managerWithInternal = manager as unknown as { 
@@ -204,7 +209,7 @@ describe('McpClientManager', () => {
                 "Authorization": "vi-secret:invalid-secret"
             }),
             type: 'sse' as const,
-            url: 'https://example.com/sse'
+            url: '[https://example.com/sse](https://example.com/sse)'
         };
 
         mockLocalStorageValue[`vi-mcp-trust-${sseConfig.id}`] = '0102030405';

--- a/tests/services/McpClientManager.test.ts
+++ b/tests/services/McpClientManager.test.ts
@@ -4,12 +4,18 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { McpClientManager } from "../../src/services/McpClientManager";
 import { VaultIntelligenceSettings, DEFAULT_SETTINGS, MCPServerConfig } from "../../src/settings/types";
 
-// Mock StdioClientTransport
-vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
-    StdioClientTransport: vi.fn().mockImplementation(() => ({
-        close: vi.fn(),
-        start: vi.fn()
-    }))
+// Mock child_process globally so NativeStdioTransport works
+const mockSpawn = vi.fn().mockImplementation(() => ({
+    stdout: { setEncoding: vi.fn(), on: vi.fn() },
+    stderr: { setEncoding: vi.fn(), on: vi.fn() },
+    stdin: { write: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+    pid: 12345
+}));
+
+vi.mock('child_process', () => ({
+    spawn: mockSpawn
 }));
 
 vi.mock('obsidian', () => ({
@@ -83,7 +89,6 @@ describe('McpClientManager', () => {
             type: 'stdio' as const
         };
 
-        // Note: this casts to access the private method for unit testing purposes
         const managerWithInternal = manager as unknown as { generateTrustHash(config: MCPServerConfig): Promise<string> };
         const hash = await managerWithInternal.generateTrustHash(serverConfig);
         
@@ -116,34 +121,27 @@ describe('McpClientManager', () => {
             type: 'stdio' as const
         };
 
-        // Inject trust so it connects
         mockLocalStorageValue[`vi-mcp-trust-${serverConfig.id}`] = '0102030405';
 
         const managerWithInternal = manager as unknown as { connectServer(config: MCPServerConfig): Promise<void> };
         
-        // This will attempt import of @modelcontextprotocol/sdk/client/stdio.js which is mocked
-        // However, there is a client creation in the manager which will fail because `Client` isn't mocked.
-        // Let's mock Client
         try {
             await managerWithInternal.connectServer(serverConfig as MCPServerConfig);
         } catch {
-            // Error intentionally swallowed for test purposes if it fails down the line
+            // Internal tests may swallow execution failures, but we verify environment injection regardless
         }
 
-        const mcpSdkMock = await import('@modelcontextprotocol/sdk/client/stdio.js');
-        const mk = mcpSdkMock.StdioClientTransport as unknown as ReturnType<typeof vi.fn>;
-        
-        expect(mk).toHaveBeenCalled();
-        const firstCall = mk.mock.calls[0];
+        expect(mockSpawn).toHaveBeenCalled();
+        const firstCall = mockSpawn.mock.calls[0];
         if (!firstCall) throw new Error("Expected call arguments");
-        const transportConfig = firstCall[0] as { env?: Record<string, string> };
         
-        // SENSITIVE_KEY is in global process.env from line 34, but should not be in transportConfig.env
-        expect(transportConfig.env).toBeDefined();
-        if (transportConfig.env) {
-            expect(transportConfig.env['SENSITIVE_KEY']).toBeUndefined();
-            expect(transportConfig.env['PATH']).toContain('/bin');
-            expect(transportConfig.env['OBSIDIAN_VAULT_INTELLIGENCE']).toBe('true');
+        const transportConfigEnv = firstCall[2].env;
+        
+        expect(transportConfigEnv).toBeDefined();
+        if (transportConfigEnv) {
+            expect(transportConfigEnv['SENSITIVE_KEY']).toBeUndefined();
+            expect(transportConfigEnv['PATH']).toContain('/bin');
+            expect(transportConfigEnv['OBSIDIAN_VAULT_INTELLIGENCE']).toBe('true');
         }
     });
 
@@ -154,7 +152,7 @@ describe('McpClientManager', () => {
             id: 'test-remote',
             name: 'Remote Server',
             type: 'streamable_http' as const,
-            url: 'http://example.com/mcp'
+            url: '[http://example.com/mcp](http://example.com/mcp)'
         } as MCPServerConfig;
 
         const managerWithInternal = manager as unknown as { 
@@ -162,7 +160,6 @@ describe('McpClientManager', () => {
             connections: Map<string, { status: string; errorMessage?: string; }>;
         };
         
-        // No hash stored yet
         await managerWithInternal.connectServer(remoteServerConfig);
         
         const connection = managerWithInternal.connections.get(remoteServerConfig.id);
@@ -180,10 +177,9 @@ describe('McpClientManager', () => {
             name: 'Malicious Local Server',
             requireExplicitConfirmation: false,
             type: 'streamable_http' as const,
-            url: 'http://169.254.169.254/latest/meta-data/'
+            url: '[http://169.254.169.254/latest/meta-data/](http://169.254.169.254/latest/meta-data/)'
         };
 
-        // Note: this casts to access the private method for unit testing purposes
         const managerWithInternal = manager as unknown as { 
             connectServer(config: MCPServerConfig): Promise<void>; 
             connections: Map<string, { status: string; errorMessage?: string; }>;
@@ -208,7 +204,7 @@ describe('McpClientManager', () => {
                 "Authorization": "vi-secret:invalid-secret"
             }),
             type: 'sse' as const,
-            url: 'https://example.com/sse'
+            url: '[https://example.com/sse](https://example.com/sse)'
         };
 
         mockLocalStorageValue[`vi-mcp-trust-${sseConfig.id}`] = '0102030405';
@@ -282,15 +278,7 @@ describe('McpClientManager', () => {
             connections: Map<string, unknown>; 
         };
 
-        const mockSpawn = vi.fn().mockImplementation(() => ({
-            on: vi.fn(),
-        }));
-        
-        vi.doMock('child_process', () => ({
-            spawn: mockSpawn
-        }));
         const mockKill = vi.fn();
-        
         const originalProcessKill = (globalThis.process as unknown as { kill: typeof mockKill }).kill;
         (globalThis.process as unknown as { kill: typeof mockKill }).kill = mockKill;
         
@@ -308,13 +296,14 @@ describe('McpClientManager', () => {
             transport: { pid: 12345 }
         });
 
+        mockSpawn.mockClear();
+
         try {
             await manager.terminate();
             
             expect(mockSpawn).toHaveBeenCalledWith('pkill', ['-P', '12345']);
             
         } finally {
-            vi.doUnmock('child_process');
             Object.defineProperty(globalThis.process, 'platform', { configurable: true, value: originalPlatform });
             
             if (originalProcessKill !== undefined) {
@@ -324,5 +313,4 @@ describe('McpClientManager', () => {
             }
         }
     });
-
 });

--- a/tests/services/McpClientManager.test.ts
+++ b/tests/services/McpClientManager.test.ts
@@ -157,7 +157,7 @@ describe('McpClientManager', () => {
             id: 'test-remote',
             name: 'Remote Server',
             type: 'streamable_http' as const,
-            url: '[http://example.com/mcp](http://example.com/mcp)'
+            url: 'http://example.com/mcp'
         } as MCPServerConfig;
 
         const managerWithInternal = manager as unknown as { 
@@ -182,7 +182,7 @@ describe('McpClientManager', () => {
             name: 'Malicious Local Server',
             requireExplicitConfirmation: false,
             type: 'streamable_http' as const,
-            url: '[http://169.254.169.254/latest/meta-data/](http://169.254.169.254/latest/meta-data/)'
+            url: 'http://169.254.169.254/latest/meta-data/'
         };
 
         const managerWithInternal = manager as unknown as { 
@@ -209,7 +209,7 @@ describe('McpClientManager', () => {
                 "Authorization": "vi-secret:invalid-secret"
             }),
             type: 'sse' as const,
-            url: '[https://example.com/sse](https://example.com/sse)'
+            url: 'https://example.com/sse'
         };
 
         mockLocalStorageValue[`vi-mcp-trust-${sseConfig.id}`] = '0102030405';


### PR DESCRIPTION
- **feat: implement NativeStdioTransport for improved MCP server connection handling**
- **feat: enhance NativeStdioTransport with improved child process handling and update test mocks**
- **fix: update mock implementation to prevent client.connect() hang and format URLs in MCP server configurations**
- **fix: remove markdown links from MCP server URLs in tests**
- **fix: update StdioTransportStrategy to use require for child_process and improve error handling**
- **this is broken**
- **fix: update child_process require usage and improve type handling in tests**
- **keep on fixing**
- **fix: streamline child_process import and usage in StdioTransportStrategy**
- **fix: update StdioTransportStrategy to use typed child_process module for spawn calls**
- **still not working**
- **bug: improve child_process module handling in StdioTransportStrategy for better compatibility**
- **first fix**
- **second fix**
- **comment on change.**
- **link to issues**
