### PR TITLE
fix/timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Security fixes should be added to a `### Security` section and include the CVE a
 ## [Unreleased]
 
 -   Refactor: Move hardcoded retry delays and backoff limits to centralized `RETRY_CONSTANTS` in `src/constants.ts`.
+-   Optimization: Removed redundant 500ms fixed delay between Voyage AI embedding batches, relying instead on centralized exponential backoff.
 
 ### User features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,18 @@ Security fixes should be added to a `### Security` section and include the CVE a
 
 ## [Unreleased]
 
+### User features
+
+-   Speed up embeddings when using Voyage AI as the provider.
+
+### Developer features
+
 -   Refactor: Move hardcoded retry delays and backoff limits to centralized `RETRY_CONSTANTS` in `src/constants.ts`.
 -   Optimization: Removed redundant 500ms fixed delay between Voyage AI embedding batches, relying instead on centralized exponential backoff.
 -   Fix: Applied missing backoff cap to `GeminiProvider` to prevent unbounded delay growth during retries.
 -   Fix: Improved `Retry-After` header parsing in `VoyageAIProvider` to be case-insensitive and support HTTP-date formats.
 -   Refactor: Harmonized transient error detection and added jittered backoff to `GeminiProvider` for better reliability.
 -   Refactor: Extracted `retryOperation` into a centralized utility in `src/utils/retry.ts` to unify exponential backoff logic across providers.
-
-### User features
-
-### Developer features
 
 ## [9.4.5] - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Security fixes should be added to a `### Security` section and include the CVE a
 -   Fix: Applied missing backoff cap to `GeminiProvider` to prevent unbounded delay growth during retries.
 -   Fix: Improved `Retry-After` header parsing in `VoyageAIProvider` to be case-insensitive and support HTTP-date formats.
 -   Refactor: Harmonized transient error detection and added jittered backoff to `GeminiProvider` for better reliability.
+-   Refactor: Extracted `retryOperation` into a centralized utility in `src/utils/retry.ts` to unify exponential backoff logic across providers.
 
 ### User features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Security fixes should be added to a `### Security` section and include the CVE a
 
 -   Refactor: Move hardcoded retry delays and backoff limits to centralized `RETRY_CONSTANTS` in `src/constants.ts`.
 -   Optimization: Removed redundant 500ms fixed delay between Voyage AI embedding batches, relying instead on centralized exponential backoff.
+-   Fix: Applied missing backoff cap to `GeminiProvider` to prevent unbounded delay growth during retries.
 
 ### User features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Security fixes should be added to a `### Security` section and include the CVE a
 -   Optimization: Removed redundant 500ms fixed delay between Voyage AI embedding batches, relying instead on centralized exponential backoff.
 -   Fix: Applied missing backoff cap to `GeminiProvider` to prevent unbounded delay growth during retries.
 -   Fix: Improved `Retry-After` header parsing in `VoyageAIProvider` to be case-insensitive and support HTTP-date formats.
+-   Refactor: Harmonized transient error detection and added jittered backoff to `GeminiProvider` for better reliability.
 
 ### User features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Security fixes should be added to a `### Security` section and include the CVE a
 
 ## [Unreleased]
 
+-   Refactor: Move hardcoded retry delays and backoff limits to centralized `RETRY_CONSTANTS` in `src/constants.ts`.
+
 ### User features
 
 ### Developer features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Security fixes should be added to a `### Security` section and include the CVE a
 -   Refactor: Move hardcoded retry delays and backoff limits to centralized `RETRY_CONSTANTS` in `src/constants.ts`.
 -   Optimization: Removed redundant 500ms fixed delay between Voyage AI embedding batches, relying instead on centralized exponential backoff.
 -   Fix: Applied missing backoff cap to `GeminiProvider` to prevent unbounded delay growth during retries.
+-   Fix: Improved `Retry-After` header parsing in `VoyageAIProvider` to be case-insensitive and support HTTP-date formats.
 
 ### User features
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -468,3 +468,10 @@ export const WORKER_LATENCY_CONSTANTS = {
     /** Multiple of chunk size allowed in the fast-path search */
     LATENCY_BUDGET_FACTOR: 4.0
 };
+
+export const RETRY_CONSTANTS = {
+    /** Initial delay for exponential backoff (ms) */
+    INITIAL_DELAY_MS: 1000,
+    /** Maximum delay for exponential backoff (ms) */
+    MAX_BACKOFF_MS: 60000
+};

--- a/src/services/GeminiProvider.ts
+++ b/src/services/GeminiProvider.ts
@@ -2,7 +2,7 @@ import { Content, EmbedContentConfig, FunctionDeclaration, GenerateContentParame
 import { App, Notice } from "obsidian";
 import { z } from "zod";
 
-import { MODEL_CONSTANTS, SEARCH_CONSTANTS } from "../constants";
+import { MODEL_CONSTANTS, RETRY_CONSTANTS, SEARCH_CONSTANTS } from "../constants";
 import { VaultIntelligenceSettings } from "../settings";
 import { ChatOptions, IEmbeddingClient, IModelProvider, IReasoningClient, IToolDefinition, ProviderError, StreamChunk, ToolCall, UnifiedMessage } from "../types/providers";
 import { logger } from "../utils/logger";
@@ -646,7 +646,7 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
 
     private async retryOperation<T>(operation: () => Promise<T>, retries: number = this.settings.geminiRetries): Promise<T> {
         let lastError: Error | null = null;
-        let delay = 1000;
+        let delay = RETRY_CONSTANTS.INITIAL_DELAY_MS;
         for (let attempt = 0; attempt < retries; attempt++) {
             try {
                 return await operation();

--- a/src/services/GeminiProvider.ts
+++ b/src/services/GeminiProvider.ts
@@ -2,11 +2,11 @@ import { Content, EmbedContentConfig, FunctionDeclaration, GenerateContentParame
 import { App, Notice } from "obsidian";
 import { z } from "zod";
 
-import { MODEL_CONSTANTS, RETRY_CONSTANTS, SEARCH_CONSTANTS } from "../constants";
+import { MODEL_CONSTANTS, SEARCH_CONSTANTS } from "../constants";
 import { VaultIntelligenceSettings } from "../settings";
 import { ChatOptions, IEmbeddingClient, IModelProvider, IReasoningClient, IToolDefinition, ProviderError, StreamChunk, ToolCall, UnifiedMessage } from "../types/providers";
-import { parseRetryAfterHeader } from "../utils/headers";
 import { logger } from "../utils/logger";
+import { retryOperation } from "../utils/retry";
 import { getGoogleApiKeySecretName, hasGoogleApiKey } from "../utils/secrets";
 import { ModelRegistry } from "./ModelRegistry";
 
@@ -107,7 +107,7 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
     // --- IReasoningClient Implementation ---
 
     public async generateMessage(messages: UnifiedMessage[], options: ChatOptions): Promise<UnifiedMessage> {
-        return this.retryOperation(async () => {
+        return retryOperation(async () => {
             const client = await this.getClient();
             const contents = this.formatHistory(messages);
 
@@ -199,7 +199,7 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
             }
 
             return parsed;
-        });
+        }, "google", this.settings.geminiRetries, "Gemini");
     }
 
     public async *generateMessageStream(messages: UnifiedMessage[], options: ChatOptions): AsyncIterableIterator<StreamChunk> {
@@ -353,7 +353,7 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
     }
 
     public async generateStructured<T>(messages: UnifiedMessage[], schema: z.ZodType<T>, options: ChatOptions): Promise<T> {
-        return this.retryOperation(async () => {
+        return retryOperation(async () => {
             const client = await this.getClient();
             const contents = this.formatHistory(messages);
             
@@ -391,7 +391,7 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
                 const message = error instanceof Error ? error.message : String(error);
                 throw new ProviderError(`Failed to parse structured output: ${message}`, "google");
             }
-        });
+        }, "google", this.settings.geminiRetries, "Gemini");
     }
 
     // --- Adapters Data Mapping ---
@@ -543,7 +543,7 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
      * Web grounding goes out through here.
      */
     public async searchWithGrounding(query: string): Promise<{ text: string, tokenCount: number }> {
-        return this.retryOperation(async () => {
+        return retryOperation(async () => {
              const client = await this.getClient();
              const response = await client.models.generateContent({
                  config: { tools: [{ googleSearch: {} }] },
@@ -554,11 +554,11 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
                  text: response.text || "",
                  tokenCount: this.extractTokenCount(response, query)
              };
-        });
+        }, "google", this.settings.geminiRetries, "Gemini");
     }
 
     public async solveWithCode(query: string): Promise<{ text: string, tokenCount: number }> {
-        return this.retryOperation(async () => {
+        return retryOperation(async () => {
              const client = await this.getClient();
              const response = await client.models.generateContent({
                  config: { tools: [{ codeExecution: {} }] },
@@ -578,7 +578,7 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
                  text: resultString.trim() || "",
                  tokenCount: this.extractTokenCount(response, query)
              };
-        });
+        }, "google", this.settings.geminiRetries, "Gemini");
     }
 
     // --- IEmbeddingClient Implementation ---
@@ -602,7 +602,7 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
     }
 
     private async embedText(text: string, options: EmbedOptions = {}): Promise<{ values: number[], tokenCount: number }> {
-        return this.retryOperation(async () => {
+        return retryOperation(async () => {
             const client = await this.getClient();
             const config: EmbedContentConfig = {};
             
@@ -632,7 +632,7 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
                 tokenCount: this.extractTokenCount(result, text),
                 values: embeddings[0].values
             };
-        });
+        }, "google", this.settings.geminiRetries, "Gemini");
     }
 
     private extractTokenCount(response: unknown, fallbackText: string): number {
@@ -644,50 +644,4 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
     }
 
     // --- Utility ---
-
-    private async retryOperation<T>(operation: () => Promise<T>, retries: number = this.settings.geminiRetries): Promise<T> {
-        let lastError: Error | null = null;
-        let delay = RETRY_CONSTANTS.INITIAL_DELAY_MS;
-        for (let attempt = 0; attempt < retries; attempt++) {
-            try {
-                return await operation();
-            } catch (error: unknown) {
-                const err = error as { message?: string; status?: number; retryAfter?: number; response?: { headers?: Record<string, string> } };
-                
-                // Attempt to extract retry-after from SDK error response if available
-                if (!err.retryAfter && err.response?.headers) {
-                    err.retryAfter = parseRetryAfterHeader(err.response.headers);
-                }
-                const isTransientError = 
-                    err.status === 429 || 
-                    err.message?.includes("429") || 
-                    err.status === 503 || 
-                    err.status === 504 || 
-                    err.message?.includes("Failed to fetch");
-
-                if (isTransientError) {
-                    // Use server-provided retry-after if available, otherwise use our backoff
-                    const retryAfterMs = err.retryAfter ? err.retryAfter * 1000 : delay;
-                    
-                    // Add jitter (±10%)
-                    const jitter = 0.9 + Math.random() * 0.2;
-                    const finalDelay = Math.min(retryAfterMs * jitter, RETRY_CONSTANTS.MAX_BACKOFF_MS);
-
-                    logger.warn(`Transient error (${err.message || "unknown"}). Retrying in ${Math.round(finalDelay)}ms...`);
-                    lastError = error instanceof Error ? error : new Error(String(error));
-                    await new Promise(resolve => window.setTimeout(resolve, finalDelay));
-                    
-                    // Only increase our internal delay if the server didn't specify a time
-                    if (!err.retryAfter) {
-                        delay = Math.min(delay * 2, RETRY_CONSTANTS.MAX_BACKOFF_MS);
-                    }
-                } else {
-                    const message = err.message || "Unknown error occurred";
-                    const status = err.status;
-                    throw new ProviderError(message, "google", status);
-                }
-            }
-        }
-        throw lastError || new ProviderError("Max retries reached.", "google", 429);
-    }
 }

--- a/src/services/GeminiProvider.ts
+++ b/src/services/GeminiProvider.ts
@@ -658,7 +658,7 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
                     logger.warn(`Transient error (${err.message || "unknown"}). Retrying in ${Math.round(delay)}ms...`);
                     lastError = error instanceof Error ? error : new Error(String(error));
                     await new Promise(resolve => window.setTimeout(resolve, delay));
-                    delay *= 2; // Exponential backoff
+                    delay = Math.min(delay * 2, RETRY_CONSTANTS.MAX_BACKOFF_MS); // Exponential backoff with cap
                 } else {
                     const message = err.message || "Unknown error occurred";
                     const status = err.status;

--- a/src/services/GeminiProvider.ts
+++ b/src/services/GeminiProvider.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { MODEL_CONSTANTS, RETRY_CONSTANTS, SEARCH_CONSTANTS } from "../constants";
 import { VaultIntelligenceSettings } from "../settings";
 import { ChatOptions, IEmbeddingClient, IModelProvider, IReasoningClient, IToolDefinition, ProviderError, StreamChunk, ToolCall, UnifiedMessage } from "../types/providers";
+import { parseRetryAfterHeader } from "../utils/headers";
 import { logger } from "../utils/logger";
 import { getGoogleApiKeySecretName, hasGoogleApiKey } from "../utils/secrets";
 import { ModelRegistry } from "./ModelRegistry";
@@ -651,14 +652,35 @@ export class GeminiProvider implements IModelProvider, IReasoningClient, IEmbedd
             try {
                 return await operation();
             } catch (error: unknown) {
-                const err = error as { message?: string; status?: number };
-                const isTransientError = err.message?.includes("429") || err.status === 429 || err.message?.includes("Failed to fetch");
+                const err = error as { message?: string; status?: number; retryAfter?: number; response?: { headers?: Record<string, string> } };
+                
+                // Attempt to extract retry-after from SDK error response if available
+                if (!err.retryAfter && err.response?.headers) {
+                    err.retryAfter = parseRetryAfterHeader(err.response.headers);
+                }
+                const isTransientError = 
+                    err.status === 429 || 
+                    err.message?.includes("429") || 
+                    err.status === 503 || 
+                    err.status === 504 || 
+                    err.message?.includes("Failed to fetch");
 
                 if (isTransientError) {
-                    logger.warn(`Transient error (${err.message || "unknown"}). Retrying in ${Math.round(delay)}ms...`);
+                    // Use server-provided retry-after if available, otherwise use our backoff
+                    const retryAfterMs = err.retryAfter ? err.retryAfter * 1000 : delay;
+                    
+                    // Add jitter (±10%)
+                    const jitter = 0.9 + Math.random() * 0.2;
+                    const finalDelay = Math.min(retryAfterMs * jitter, RETRY_CONSTANTS.MAX_BACKOFF_MS);
+
+                    logger.warn(`Transient error (${err.message || "unknown"}). Retrying in ${Math.round(finalDelay)}ms...`);
                     lastError = error instanceof Error ? error : new Error(String(error));
-                    await new Promise(resolve => window.setTimeout(resolve, delay));
-                    delay = Math.min(delay * 2, RETRY_CONSTANTS.MAX_BACKOFF_MS); // Exponential backoff with cap
+                    await new Promise(resolve => window.setTimeout(resolve, finalDelay));
+                    
+                    // Only increase our internal delay if the server didn't specify a time
+                    if (!err.retryAfter) {
+                        delay = Math.min(delay * 2, RETRY_CONSTANTS.MAX_BACKOFF_MS);
+                    }
                 } else {
                     const message = err.message || "Unknown error occurred";
                     const status = err.status;

--- a/src/services/VoyageAIProvider.ts
+++ b/src/services/VoyageAIProvider.ts
@@ -170,8 +170,22 @@ export class VoyageAIProvider implements IEmbeddingClient {
                 const errorData = response.json as { error?: { message?: string } } | undefined;
                 const message = errorData?.error?.message || response.text || `Voyage API error ${response.status}`;
                 
-                const retryAfter = response.headers['retry-after'];
-                const retryAfterSec = retryAfter ? parseInt(retryAfter, 10) : undefined;
+                // Extract retry-after header (case-insensitive)
+                const retryAfterHeader = Object.entries(response.headers).find(([k]) => k.toLowerCase() === 'retry-after')?.[1];
+                let retryAfterSec: number | undefined;
+                
+                if (retryAfterHeader) {
+                    const parsed = parseInt(retryAfterHeader, 10);
+                    if (!isNaN(parsed)) {
+                        retryAfterSec = parsed;
+                    } else {
+                        // Handle HTTP-date format
+                        const date = Date.parse(retryAfterHeader);
+                        if (!isNaN(date)) {
+                            retryAfterSec = Math.max(0, Math.ceil((date - Date.now()) / 1000));
+                        }
+                    }
+                }
                 
                 throw new ProviderError(message, "voyage", response.status, retryAfterSec);
             }

--- a/src/services/VoyageAIProvider.ts
+++ b/src/services/VoyageAIProvider.ts
@@ -1,10 +1,11 @@
 import { App, Notice, requestUrl } from "obsidian";
 
-import { RETRY_CONSTANTS, SEARCH_CONSTANTS } from "../constants";
+import { SEARCH_CONSTANTS } from "../constants";
 import { VaultIntelligenceSettings } from "../settings/types";
 import { EmbeddingPriority, IEmbeddingClient, ProviderError } from "../types/providers";
 import { parseRetryAfterHeader } from "../utils/headers";
 import { logger } from "../utils/logger";
+import { retryOperation } from "../utils/retry";
 import { getVoyageApiKeySecretName, hasVoyageApiKey } from "../utils/secrets";
 
 interface VoyageResponse {
@@ -141,7 +142,7 @@ export class VoyageAIProvider implements IEmbeddingClient {
     }
 
     private async requestEmbeddings(input: string[], inputType: 'query' | 'document'): Promise<VoyageResponse> {
-        return this.retryOperation(async () => {
+        return retryOperation(async () => {
             const apiKey = await this.getApiKey();
             if (!apiKey) {
                 if (getVoyageApiKeySecretName(this.settings)) {
@@ -177,51 +178,6 @@ export class VoyageAIProvider implements IEmbeddingClient {
             }
 
             return response.json as VoyageResponse;
-        });
-    }
-
-    private async retryOperation<T>(operation: () => Promise<T>, retries: number = this.settings.voyageRetries): Promise<T> {
-        let lastError: Error | null = null;
-        let delay = RETRY_CONSTANTS.INITIAL_DELAY_MS;
-        const MAX_BACKOFF_MS = RETRY_CONSTANTS.MAX_BACKOFF_MS;
-
-        for (let attempt = 0; attempt < retries; attempt++) {
-            try {
-                return await operation();
-            } catch (error: unknown) {
-                const err = error as { message?: string; status?: number; retryAfter?: number };
-                
-                // Obsidian's requestUrl often throws an error with the status in the message.
-                // We must check both the status property and the message string.
-                const isTransientError = 
-                    err.status === 429 || 
-                    err.message?.includes("429") || 
-                    err.status === 503 || 
-                    err.status === 504 || 
-                    err.message?.includes("Failed to fetch");
-
-                if (isTransientError) {
-                    // Use server-provided retry-after if available, otherwise use our backoff
-                    const retryAfterMs = err.retryAfter ? err.retryAfter * 1000 : delay;
-                    
-                    // Add jitter (±10%) to prevent thundering herd if multiple chunks fail
-                    const jitter = 0.9 + Math.random() * 0.2;
-                    const finalDelay = Math.min(retryAfterMs * jitter, MAX_BACKOFF_MS);
-
-                    logger.warn(`Voyage transient error (${err.message || "unknown"}). Retrying in ${Math.round(finalDelay)}ms...`);
-                    
-                    lastError = error instanceof Error ? error : new Error(String(error));
-                    await new Promise(resolve => window.setTimeout(resolve, finalDelay));
-                    
-                    // Only increase our internal delay if the server didn't specify a time
-                    if (!err.retryAfter) {
-                        delay = Math.min(delay * 2, MAX_BACKOFF_MS);
-                    }
-                } else {
-                    throw error;
-                }
-            }
-        }
-        throw lastError || new ProviderError("Max retries reached.", "voyage", 429);
+        }, "voyage", this.settings.voyageRetries, "VoyageAI");
     }
 }

--- a/src/services/VoyageAIProvider.ts
+++ b/src/services/VoyageAIProvider.ts
@@ -3,6 +3,7 @@ import { App, Notice, requestUrl } from "obsidian";
 import { RETRY_CONSTANTS, SEARCH_CONSTANTS } from "../constants";
 import { VaultIntelligenceSettings } from "../settings/types";
 import { EmbeddingPriority, IEmbeddingClient, ProviderError } from "../types/providers";
+import { parseRetryAfterHeader } from "../utils/headers";
 import { logger } from "../utils/logger";
 import { getVoyageApiKeySecretName, hasVoyageApiKey } from "../utils/secrets";
 
@@ -170,22 +171,7 @@ export class VoyageAIProvider implements IEmbeddingClient {
                 const errorData = response.json as { error?: { message?: string } } | undefined;
                 const message = errorData?.error?.message || response.text || `Voyage API error ${response.status}`;
                 
-                // Extract retry-after header (case-insensitive)
-                const retryAfterHeader = Object.entries(response.headers).find(([k]) => k.toLowerCase() === 'retry-after')?.[1];
-                let retryAfterSec: number | undefined;
-                
-                if (retryAfterHeader) {
-                    const parsed = parseInt(retryAfterHeader, 10);
-                    if (!isNaN(parsed)) {
-                        retryAfterSec = parsed;
-                    } else {
-                        // Handle HTTP-date format
-                        const date = Date.parse(retryAfterHeader);
-                        if (!isNaN(date)) {
-                            retryAfterSec = Math.max(0, Math.ceil((date - Date.now()) / 1000));
-                        }
-                    }
-                }
+                const retryAfterSec = parseRetryAfterHeader(response.headers);
                 
                 throw new ProviderError(message, "voyage", response.status, retryAfterSec);
             }

--- a/src/services/VoyageAIProvider.ts
+++ b/src/services/VoyageAIProvider.ts
@@ -97,11 +97,7 @@ export class VoyageAIProvider implements IEmbeddingClient {
         let totalTokens = 0;
         const allVectors: number[][] = [];
 
-        for (const [i, batch] of batches.entries()) {
-            if (i > 0) {
-                await new Promise(resolve => window.setTimeout(resolve, 500));
-            }
-
+        for (const batch of batches) {
             const response = await this.requestEmbeddings(batch, 'document');
             totalTokens += response.usage.total_tokens;
             

--- a/src/services/VoyageAIProvider.ts
+++ b/src/services/VoyageAIProvider.ts
@@ -1,6 +1,6 @@
 import { App, Notice, requestUrl } from "obsidian";
 
-import { SEARCH_CONSTANTS } from "../constants";
+import { RETRY_CONSTANTS, SEARCH_CONSTANTS } from "../constants";
 import { VaultIntelligenceSettings } from "../settings/types";
 import { EmbeddingPriority, IEmbeddingClient, ProviderError } from "../types/providers";
 import { logger } from "../utils/logger";
@@ -186,8 +186,8 @@ export class VoyageAIProvider implements IEmbeddingClient {
 
     private async retryOperation<T>(operation: () => Promise<T>, retries: number = this.settings.voyageRetries): Promise<T> {
         let lastError: Error | null = null;
-        let delay = 1000;
-        const MAX_BACKOFF_MS = 60000; // Cap backoff at 60 seconds
+        let delay = RETRY_CONSTANTS.INITIAL_DELAY_MS;
+        const MAX_BACKOFF_MS = RETRY_CONSTANTS.MAX_BACKOFF_MS;
 
         for (let attempt = 0; attempt < retries; attempt++) {
             try {

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -72,3 +72,22 @@ export function mergeHeaders(...headersList: Array<Record<string, string> | unde
     
     return merged;
 }
+
+/**
+ * Parse a Retry-After header value into seconds.
+ * Supports both integer seconds and HTTP-date formats.
+ */
+export function parseRetryAfterHeader(headers: Record<string, string>): number | undefined {
+    const retryAfterHeader = Object.entries(headers).find(([k]) => k.toLowerCase() === 'retry-after')?.[1];
+    if (!retryAfterHeader) return undefined;
+
+    const parsed = parseInt(retryAfterHeader, 10);
+    if (!isNaN(parsed)) return parsed;
+
+    const date = Date.parse(retryAfterHeader);
+    if (!isNaN(date)) {
+        return Math.max(0, Math.ceil((date - Date.now()) / 1000));
+    }
+
+    return undefined;
+}

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -69,5 +69,10 @@ export async function retryOperation<T>(
             }
         }
     }
-    throw lastError || new ProviderError("Max retries reached.", provider, 429);
+    
+    // If we've exhausted retries, wrap the last error in a ProviderError
+    if (lastError instanceof ProviderError) {
+        throw lastError;
+    }
+    throw new ProviderError(lastError?.message || "Max retries reached.", provider, 429);
 }

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -52,7 +52,9 @@ export async function retryOperation<T>(
                 logger.warn(`[${loggerPrefix}] Transient error (${err.message || "unknown"}). Retrying in ${Math.round(finalDelay)}ms...`);
                 
                 lastError = error instanceof Error ? error : new Error(String(error));
-                await new Promise(resolve => window.setTimeout(resolve, finalDelay));
+                if (attempt < retries - 1) {
+                    await new Promise(resolve => window.setTimeout(resolve, finalDelay));
+                }
                 
                 // Only increase our internal delay if the server didn't specify a time
                 if (!err.retryAfter) {

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,73 @@
+import { RETRY_CONSTANTS } from "../constants";
+import { ProviderError } from "../types/providers";
+import { parseRetryAfterHeader } from "./headers";
+import { logger } from "./logger";
+
+/**
+ * Executes an operation with exponential backoff and jittered retries.
+ * Respects Retry-After headers and transient error status codes.
+ */
+export async function retryOperation<T>(
+    operation: () => Promise<T>,
+    provider: string,
+    retries: number,
+    loggerPrefix: string = provider
+): Promise<T> {
+    let lastError: Error | null = null;
+    let delay = RETRY_CONSTANTS.INITIAL_DELAY_MS;
+    const MAX_BACKOFF_MS = RETRY_CONSTANTS.MAX_BACKOFF_MS;
+
+    for (let attempt = 0; attempt < retries; attempt++) {
+        try {
+            return await operation();
+        } catch (error: unknown) {
+            const err = error as { 
+                message?: string; 
+                status?: number; 
+                retryAfter?: number;
+                response?: { headers?: Record<string, string> }
+            };
+
+            // Attempt to extract retry-after from SDK error response if available
+            if (!err.retryAfter && err.response?.headers) {
+                err.retryAfter = parseRetryAfterHeader(err.response.headers);
+            }
+
+            // Check if error is transient (Rate limit 429, or server errors 503, 504, or network failure)
+            const isTransientError = 
+                err.status === 429 || 
+                err.message?.includes("429") || 
+                err.status === 503 || 
+                err.status === 504 || 
+                err.message?.includes("Failed to fetch");
+
+            if (isTransientError) {
+                // Use server-provided retry-after if available, otherwise use our backoff
+                const retryAfterMs = err.retryAfter ? err.retryAfter * 1000 : delay;
+                
+                // Add jitter (±10%) to prevent thundering herd
+                const jitter = 0.9 + Math.random() * 0.2;
+                const finalDelay = Math.min(retryAfterMs * jitter, MAX_BACKOFF_MS);
+
+                logger.warn(`[${loggerPrefix}] Transient error (${err.message || "unknown"}). Retrying in ${Math.round(finalDelay)}ms...`);
+                
+                lastError = error instanceof Error ? error : new Error(String(error));
+                await new Promise(resolve => window.setTimeout(resolve, finalDelay));
+                
+                // Only increase our internal delay if the server didn't specify a time
+                if (!err.retryAfter) {
+                    delay = Math.min(delay * 2, MAX_BACKOFF_MS);
+                }
+            } else {
+                // Not a transient error, re-throw immediately
+                if (error instanceof ProviderError) {
+                    throw error;
+                }
+                const message = err.message || "Unknown error occurred";
+                const status = err.status;
+                throw new ProviderError(message, provider, status);
+            }
+        }
+    }
+    throw lastError || new ProviderError("Max retries reached.", provider, 429);
+}

--- a/tests/headers.test.ts
+++ b/tests/headers.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
 import { parseRetryAfterHeader } from "../src/utils/headers";
 
 describe("parseRetryAfterHeader", () => {

--- a/tests/headers.test.ts
+++ b/tests/headers.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { parseRetryAfterHeader } from "../src/utils/headers";
+
+describe("parseRetryAfterHeader", () => {
+    beforeAll(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-05-14T18:00:00Z"));
+    });
+
+    afterAll(() => {
+        vi.useRealTimers();
+    });
+
+    it("should parse integer seconds", () => {
+        expect(parseRetryAfterHeader({ "retry-after": "30" })).toBe(30);
+    });
+
+    it("should be case-insensitive", () => {
+        expect(parseRetryAfterHeader({ "Retry-After": "45" })).toBe(45);
+    });
+
+    it("should parse HTTP-date format", () => {
+        const dateStr = "Thu, 14 May 2026 18:00:30 GMT";
+        expect(parseRetryAfterHeader({ "retry-after": dateStr })).toBe(30);
+    });
+
+    it("should return 0 for dates in the past", () => {
+        const dateStr = "Thu, 14 May 2026 17:59:00 GMT";
+        expect(parseRetryAfterHeader({ "retry-after": dateStr })).toBe(0);
+    });
+
+    it("should return undefined if header is missing", () => {
+        expect(parseRetryAfterHeader({})).toBeUndefined();
+    });
+
+    it("should return undefined for invalid formats", () => {
+        expect(parseRetryAfterHeader({ "retry-after": "not-a-date" })).toBeUndefined();
+    });
+});

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { retryOperation } from "../src/utils/retry";
+import { ProviderError } from "../src/types/providers";
+
+vi.mock("../src/utils/logger", () => ({
+    logger: {
+        warn: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn()
+    }
+}));
+
+describe("retryOperation", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.clearAllMocks();
+    });
+
+    it("should return result on first success", async () => {
+        const op = vi.fn().mockResolvedValue("success");
+        const result = await retryOperation(op, "test", 3);
+        expect(result).toBe("success");
+        expect(op).toHaveBeenCalledTimes(1);
+    });
+
+    it("should retry on transient errors and eventually succeed", async () => {
+        const op = vi.fn()
+            .mockRejectedValueOnce(new Error("Rate limit 429"))
+            .mockResolvedValueOnce("success");
+
+        const promise = retryOperation(op, "test", 3);
+        
+        await vi.runAllTimersAsync();
+        
+        const result = await promise;
+        expect(result).toBe("success");
+        expect(op).toHaveBeenCalledTimes(2);
+    });
+
+    it("should throw ProviderError after max retries", async () => {
+        const op = vi.fn().mockRejectedValue(new Error("Rate limit 429"));
+        
+        const promise = retryOperation(op, "test", 2);
+
+        // We must advance timers to allow the retry logic to progress
+        await vi.runAllTimersAsync();
+        
+        // Wait for the final rejection
+        await expect(promise).rejects.toThrow(ProviderError);
+        expect(op).toHaveBeenCalledTimes(2);
+    });
+
+    it("should fail immediately on non-transient errors", async () => {
+        const op = vi.fn().mockRejectedValue(new Error("Bad Request"));
+        await expect(retryOperation(op, "test", 3)).rejects.toThrow(ProviderError);
+        expect(op).toHaveBeenCalledTimes(1);
+    });
+
+    it("should respect Retry-After header if available", async () => {
+        const error: any = new Error("Rate limit 429");
+        error.status = 429;
+        error.response = { headers: { "retry-after": "10" } };
+        
+        const op = vi.fn()
+            .mockRejectedValueOnce(error)
+            .mockResolvedValueOnce("success");
+
+        const promise = retryOperation(op, "test", 3);
+        
+        await vi.runAllTimersAsync();
+        
+        const result = await promise;
+        expect(result).toBe("success");
+        expect(op).toHaveBeenCalledTimes(2);
+    });
+});

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { retryOperation } from "../src/utils/retry";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 import { ProviderError } from "../src/types/providers";
+import { retryOperation } from "../src/utils/retry";
 
 vi.mock("../src/utils/logger", () => ({
     logger: {
-        warn: vi.fn(),
+        debug: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
-        debug: vi.fn()
+        warn: vi.fn()
     }
 }));
 
@@ -62,7 +63,7 @@ describe("retryOperation", () => {
     });
 
     it("should respect Retry-After header if available", async () => {
-        const error: any = new Error("Rate limit 429");
+        const error = new Error("Rate limit 429") as Error & { status?: number; response?: { headers?: Record<string, string> } };
         error.status = 429;
         error.response = { headers: { "retry-after": "10" } };
         

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 import { ProviderError } from "../src/types/providers";
 import { retryOperation } from "../src/utils/retry";
@@ -47,23 +47,35 @@ describe("retryOperation", () => {
         const op = vi.fn().mockRejectedValue(new Error("Rate limit 429"));
         
         const promise = retryOperation(op, "test", 2);
-
-        // We must advance timers to allow the retry logic to progress
+        // Catch it immediately to prevent unhandled rejection
+        const errorPromise = promise.catch((e: unknown) => e);
+        
         await vi.runAllTimersAsync();
         
-        // Wait for the final rejection
-        await expect(promise).rejects.toThrow(ProviderError);
+        const error = await errorPromise;
+        expect(error).toBeInstanceOf(ProviderError);
+        const providerError = error as ProviderError;
+        expect(providerError.status).toBe(429);
         expect(op).toHaveBeenCalledTimes(2);
     });
 
     it("should fail immediately on non-transient errors", async () => {
         const op = vi.fn().mockRejectedValue(new Error("Bad Request"));
-        await expect(retryOperation(op, "test", 3)).rejects.toThrow(ProviderError);
+        
+        const promise = retryOperation(op, "test", 3);
+        const errorPromise = promise.catch((e: unknown) => e);
+
+        const error = await errorPromise;
+        expect(error).toBeInstanceOf(ProviderError);
         expect(op).toHaveBeenCalledTimes(1);
     });
 
     it("should respect Retry-After header if available", async () => {
-        const error = new Error("Rate limit 429") as Error & { status?: number; response?: { headers?: Record<string, string> } };
+        interface MockError extends Error {
+            response?: { headers?: Record<string, string> };
+            status?: number;
+        }
+        const error = new Error("Rate limit 429") as MockError;
         error.status = 429;
         error.response = { headers: { "retry-after": "10" } };
         


### PR DESCRIPTION
- **Refactor: Move hardcoded retry delays and backoff limits to centralized `RETRY_CONSTANTS` in `src/constants.ts`**
- **Removed redundant 500ms fixed delay between Voyage AI embedding batches**
- **Applied missing backoff cap to `GeminiProvider` to prevent unbounded delay growth during retries.**
- **fix: Improved `Retry-After` header parsing in `VoyageAIProvider` to be case-insensitive and support HTTP-date formats.**
- **fix: added missing retry-after parsing and logic to the Gemini Provider.**
- **refactor retry**
- **test scripts for refactored code**
- **fix/lint errors**
- **test/fix error**
