### PR TITLE
Restating the `$protobujs` override now that we know it is a bug in the Obsidian scanner.

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "vite": "$vite",
     "@vitejs/plugin-vue": "^6.0.6",
     "vitepress": "2.0.0-alpha.17",
-    "protobufjs": "^8.6.3",
+    "protobufjs": "$protobufjs",
     "uuid": "^14.0.0",
     "fetch-blob": "^4.0.0",
     "ip-address": "10.2.0",


### PR DESCRIPTION
https://discord.com/channels/686053708261228577/1515318265415733348/1515487925293551676
